### PR TITLE
Add libglew-dev requirement for Linux SDL2 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The game currently supports two different platform-backends: [SDL2](https://gith
 
 ```
 # for SDL2 backend
-apt install libsdl2-dev
+apt install libsdl2-dev libglew-dev
 make sdl
 ```
 


### PR DESCRIPTION
I found I needed to install `libglew-dev` in order to compile with SDL2 on Linux. SDL was already there, libglew was not.