### PR TITLE
Use appropriate platform-specific paths, and SDL implementation

### DIFF
--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -250,6 +250,25 @@ void set_save_path() {
 
 	SDL_free(base_path);
 }
+
+#if !defined(__APPLE__)
+uint8_t *asset_load(char *path, uint32_t *bytes_read) {
+	static char* base_path = NULL;
+	static char temp_path[PATH_MAX] = "";
+
+	if (base_path == NULL) {
+		// This is not necessarily a fast call, so you should call this once near startup and save the string if you need it.
+		// The pointer returned is owned by the caller.
+		base_path = SDL_GetBasePath();
+	}
+
+	memset(temp_path, 0, PATH_MAX);
+	strcpy(temp_path, base_path);
+	strcpy(temp_path + strlen(base_path), path);
+
+	return file_load(temp_path, bytes_read);
+}
+#endif
 #endif
 
 

--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -3,6 +3,9 @@
 #include "platform.h"
 #include "input.h"
 #include "system.h"
+#include "utils.h"
+
+extern char save_file_path[PATH_MAX];
 
 static uint64_t perf_freq = 0;
 static bool wants_to_exit = false;
@@ -238,6 +241,16 @@ void platform_set_audio_mix_cb(void (*cb)(float *buffer, uint32_t len)) {
 	#error "Unsupported renderer for platform SDL"
 #endif
 
+#if !defined(__EMSCRIPTEN__)
+void set_save_path() {
+	char * base_path = SDL_GetPrefPath("PhobosLab", "wipEout");
+	memset(save_file_path, 0, PATH_MAX);
+	strcpy(save_file_path, base_path);
+	strcpy(save_file_path + strlen(base_path), "save.dat");
+
+	SDL_free(base_path);
+}
+#endif
 
 
 int main(int argc, char *argv[]) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -5,7 +5,7 @@
 #include "utils.h"
 #include "mem.h"
 
-char temp_path[64];
+char temp_path[PATH_MAX];
 char *get_path(const char *dir, const char *file) {
 	strcpy(temp_path, dir);
 	strcpy(temp_path + strlen(dir), file);

--- a/src/utils.c
+++ b/src/utils.c
@@ -43,6 +43,10 @@ uint8_t *file_load(char *path, uint32_t *bytes_read) {
 	return bytes;
 }
 
+__attribute__((weak)) uint8_t *asset_load(char *path, uint32_t *bytes_read) {
+	return file_load(path, bytes_read);
+}
+
 uint32_t file_store(char *path, void *bytes, int32_t len) {
 	FILE *f = fopen(path, "wb");
 	error_if(!f, "Could not open file for writing: %s", path);

--- a/src/utils.h
+++ b/src/utils.h
@@ -86,8 +86,19 @@ float rand_float(float min, float max);
 int32_t rand_int(int32_t min, int32_t max); 
 
 bool file_exists(char *path);
+/**
+ * Generic function handling any file load.
+ *
+ * NOTE: Use `asset_load` to load a game asset.
+ */
 uint8_t *file_load(char *path, uint32_t *bytes_read);
 uint32_t file_store(char *path, void *bytes, int32_t len);
+/**
+ * Specialization of `file_load` which will prepend the appropriate asset path prefix.
+ *
+ * This can be used by platform-specific code to redirect asset location to the appropriate location.
+ */
+uint8_t *asset_load(char *path, uint32_t *bytes_read);
 
 
 #define sort(LIST, LEN, COMPARE_FUNC) \

--- a/src/utils.h
+++ b/src/utils.h
@@ -4,6 +4,20 @@
 #include <string.h>
 #include "types.h"
 
+#if defined(__linux__)
+#	include <linux/limits.h>
+#elif defined(_WIN32)
+#	include <windows.h>
+#	define PATH_MAX MAX_PATH
+#elif defined(__APPLE__)
+#	include <sys/syslimits.h>
+#endif
+
+/* Fallback */
+#ifndef PATH_MAX
+#	define PATH_MAX 1024
+#endif
+
 
 #if !defined(offsetof)
 	#define offsetof(TYPE, ELEMENT) ((size_t)&(((TYPE *)0)->ELEMENT))

--- a/src/wipeout/game.c
+++ b/src/wipeout/game.c
@@ -489,10 +489,19 @@ static game_scene_t scene_next = GAME_SCENE_NONE;
 static int global_textures_len = 0;
 static void *global_mem_mark = 0;
 
+char save_file_path[PATH_MAX] = "save.dat";
+
+__attribute__((weak)) void set_save_path() {
+	/* No-op */
+	return;
+}
+
 void game_init() {
-	if (file_exists("save.dat")) {
+	set_save_path();
+
+	if (file_exists(save_file_path)) {
 		uint32_t size;
-		save_t *save_file = (save_t *)file_load("save.dat", &size);
+		save_t *save_file = (save_t *)file_load(save_file_path, &size);
 		if (size == sizeof(save_t) && save_file->magic == SAVE_DATA_MAGIC) {
 			printf("load save data success\n");
 			memcpy(&save, save_file, sizeof(save_t));
@@ -636,8 +645,8 @@ void game_update() {
 		// FIXME: use a text based format?
 		// FIXME: this should probably run async somewhere
 		save.is_dirty = false;
-		file_store("save.dat", &save, sizeof(save_t)); 
-		printf("wrote save.dat\n");
+		file_store(save_file_path, &save, sizeof(save_t)); 
+		printf("wrote '%s'\n", save_file_path);
 	}
 
 	double now = platform_now();

--- a/src/wipeout/image.c
+++ b/src/wipeout/image.c
@@ -226,7 +226,7 @@ void lzss_decompress(uint8_t *in_data, uint8_t *out_data) {
 cmp_t *image_load_compressed(char *name) {
 	printf("load cmp %s\n", name);
 	uint32_t compressed_size;
-	uint8_t *compressed_bytes = file_load(name, &compressed_size);
+	uint8_t *compressed_bytes = asset_load(name, &compressed_size);
 
 	uint32_t p = 0;
 	int32_t decompressed_size = 0;
@@ -260,7 +260,7 @@ cmp_t *image_load_compressed(char *name) {
 uint16_t image_get_texture(char *name) {
 	printf("load: %s\n", name);
 	uint32_t size;
-	uint8_t *bytes = file_load(name, &size);
+	uint8_t *bytes = asset_load(name, &size);
 	image_t *image = image_load_from_bytes(bytes, false);
 	uint32_t texture_index = render_texture_create(image->width, image->height, image->pixels);
 	mem_temp_free(image);
@@ -272,7 +272,7 @@ uint16_t image_get_texture(char *name) {
 uint16_t image_get_texture_semi_trans(char *name) {
 	printf("load: %s\n", name);
 	uint32_t size;
-	uint8_t *bytes = file_load(name, &size);
+	uint8_t *bytes = asset_load(name, &size);
 	image_t *image = image_load_from_bytes(bytes, true);
 	uint32_t texture_index = render_texture_create(image->width, image->height, image->pixels);
 	mem_temp_free(image);

--- a/src/wipeout/object.c
+++ b/src/wipeout/object.c
@@ -26,7 +26,7 @@ static rgba_t int32_to_rgba(uint32_t v) {
 
 Object *objects_load(char *name, texture_list_t tl) {
 	uint32_t length = 0;
-	uint8_t *bytes = file_load(name, &length);
+	uint8_t *bytes = asset_load(name, &length);
 	if (!bytes) {
 		die("Failed to load file %s\n", name);
 	}

--- a/src/wipeout/sfx.c
+++ b/src/wipeout/sfx.c
@@ -67,7 +67,7 @@ void sfx_load() {
 
 	// 16 byte blocks: 2 byte header, 14 bytes with 2x4bit samples each
 	uint32_t vb_size;
-	uint8_t *vb = file_load("wipeout/sound/wipeout.vb", &vb_size);
+	uint8_t *vb = asset_load("wipeout/sound/wipeout.vb", &vb_size);
 	uint32_t num_samples = (vb_size / 16) * 28;
 
 	int16_t *sample_buffer = mem_bump(num_samples * sizeof(int16_t));

--- a/src/wipeout/track.c
+++ b/src/wipeout/track.c
@@ -87,7 +87,7 @@ void track_load(const char *base_path) {
 
 ttf_t *track_load_tile_format(char *ttf_name) {
 	uint32_t ttf_size;
-	uint8_t *ttf_bytes = file_load(ttf_name, &ttf_size);
+	uint8_t *ttf_bytes = asset_load(ttf_name, &ttf_size);
 
 	uint32_t p = 0;
 	uint32_t num_tiles = ttf_size / 42;
@@ -123,7 +123,7 @@ bool track_collect_pickups(track_face_t *face) {
 
 vec3_t *track_load_vertices(char *file_name) {
 	uint32_t size;
-	uint8_t *bytes = file_load(file_name, &size);
+	uint8_t *bytes = asset_load(file_name, &size);
 
 	g.track.vertex_count = size / 16; // VECTOR_SIZE
 	vec3_t *vertices = mem_temp_alloc(sizeof(vec3_t) * g.track.vertex_count);
@@ -147,7 +147,7 @@ static const vec2_t track_uv[2][4] = {
 
 void track_load_faces(char *file_name, vec3_t *vertices) {
 	uint32_t size;
-	uint8_t *bytes = file_load(file_name, &size);
+	uint8_t *bytes = asset_load(file_name, &size);
 
 	g.track.face_count = size / 20; // TRACK_FACE_DATA_SIZE
 	g.track.faces = mem_bump(sizeof(track_face_t) * g.track.face_count);
@@ -196,7 +196,7 @@ void track_load_faces(char *file_name, vec3_t *vertices) {
 
 void track_load_sections(char *file_name) {
 	uint32_t size;
-	uint8_t *bytes = file_load(file_name, &size);
+	uint8_t *bytes = asset_load(file_name, &size);
 
 	g.track.section_count = size / 156; // SECTION_DATA_SIZE
 	g.track.sections = mem_bump(sizeof(section_t) * g.track.section_count);


### PR DESCRIPTION
Hi!

This adds two pairs of changes:

1. Infra to use a more platform-appropriate location for the save file
1. Implement for SDL (except emscripten)
1. Infra to use a more platform-appropriate location for assets loading
1. Implement for SDL (except emscripten and macOS)

This makes one major change possible: installing through a package, and executing without the CWD being the project directory.

Since packaging a game would imply storing it at a read-only location, using the same path as assets wouldn't be appropriate.

Setting the CWD to the game path is inconvenient, plain and simply. Using the base path means that we don't have to worry about an additional variable.

Additionally, this should cater to more exotic platforms (Android? iOS? 3DS? Switch? etc...)

* * *

Another way, or an additional way, to solve the packaging issue would be to have a build-time define that provides the base path. It may be an option that can default to off, and disable the SDL-specific base path when defined.

For saving, frankly, there's not much better with SDL. I don't know for other platforms :).

* * *

Feel free to suggest changes if needed for code style and such. I made sure to not add any form of memory allocation.