### PR TITLE
render_gl.c: declare glFrameBufferTexture on macOS

### DIFF
--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -7,6 +7,10 @@
 	void glCreateTextures(GLuint ignored, GLsizei n, GLuint *name) {
 		glGenTextures(1, name);
 	}
+	void glFramebufferTexture(GLenum target, GLenum attachment, GLuint texture, GLint level) {
+		glFramebufferTexture2D(target, attachment, GL_TEXTURE_2D, texture, level);
+	}
+
 	#define glGenVertexArrays glGenVertexArraysAPPLE
 	#define glBindVertexArray glBindVertexArrayAPPLE
 	#define glDeleteVertexArrays glDeleteVertexArraysAPPLE


### PR DESCRIPTION
Resolves a compilation issue on macOS (previously, call to undeclared function 'glFramebufferTexture'; ISO C99 and later do not support implicit function declarations)