### PR TITLE
Add modern GLVND and explicit GLES2 support in GNU/Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CC ?= gcc
 EMCC ?= emcc
 UNAME_S := $(shell uname -s)
 RENDERER ?= GL
+USE_GLX ?= false
 DEBUG ?= false
 
 L_FLAGS ?= -lm -rdynamic
@@ -23,6 +24,9 @@ else
 $(error Unknown RENDERER)
 endif
 
+ifeq ($(GL_VERSION), GLES2)
+	C_FLAGS := $(C_FLAGS) -DUSE_GLES2
+endif
 
 
 
@@ -44,7 +48,14 @@ ifeq ($(UNAME_S), Darwin)
 
 else ifeq ($(UNAME_S), Linux)
 	ifeq ($(RENDERER), GL)
-		L_FLAGS := $(L_FLAGS) -lGLEW -lGL
+		L_FLAGS := $(L_FLAGS) -lGLEW
+
+		# Prefer modern GLVND instead of legacy X11-only GLX
+		ifeq ($(USE_GLX), true)
+			L_FLAGS := $(L_FLAGS) -lGL
+		else
+			L_FLAGS := $(L_FLAGS) -lOpenGL
+		endif
 	endif
 
 	L_FLAGS_SDL = -lSDL2

--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -219,6 +219,12 @@ void platform_set_audio_mix_cb(void (*cb)(float *buffer, uint32_t len)) {
 	SDL_GLContext platform_gl;
 
 	void platform_video_init() {
+                #if defined(USE_GLES2)
+                SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+                SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+                SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+                #endif
+
 		platform_gl = SDL_GL_CreateContext(window);
 		SDL_GL_SetSwapInterval(1);
 	}

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -55,7 +55,7 @@
 #define TEXTURES_MAX 1024
 
 
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) || defined(USE_GLES2)
 	// WebGL (GLES) needs the `precision` to be set, wheras OpenGL 2 
 	// doesn't like that...
 	#define SHADER_SOURCE(...) "precision highp float;" #__VA_ARGS__


### PR DESCRIPTION
This allows to correctly build the engine on modern, light GNU/Linux systems where GLX support is absent in favor or vendor-neutral GLVND in MESA (GLX supports the legacy X11 windowing system only, whereas GLVND supports Wayland, KMS/DRM, X11, etc)

Also, it allows to do specific GLES2 builds because GLES needs precission to be set (black screen if not done) as noted here:
https://github.com/phoboslab/wipeout-rewrite/blob/cb2a1eded3f7048f05615b0981b8eb17d7ed23e4/src/render_gl.c#L59

So now, the engine can be built normally (which would result on a desktop-GL based build against modern GLVND) or it can be built for light embedded systems like this:

`GL_VERSION=GLES2 make sdl`

If, for some strange reason, there's need to build against GLX (ancient Linux/MESA distros?) it can be done like this:

`USE_GLX=true make sdl`