### PR TITLE
[SDL2] Hide distracting mouse cursor.

### DIFF
--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -188,14 +188,16 @@ double platform_now() {
 void platform_set_fullscreen(bool fullscreen) {
 	if (fullscreen) {
 		int32_t display = SDL_GetWindowDisplayIndex(window);
-		
+
 		SDL_DisplayMode mode;
 		SDL_GetDesktopDisplayMode(display, &mode);
 		SDL_SetWindowDisplayMode(window, &mode);
 		SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN);
+                SDL_ShowCursor(SDL_DISABLE);		
 	}
 	else {
 		SDL_SetWindowFullscreen(window, 0);	
+                SDL_ShowCursor(SDL_ENABLE);		
 	}
 }
 
@@ -260,8 +262,6 @@ int main(int argc, char *argv[]) {
 	gamepad = platform_find_gamepad();
 
 	perf_freq = SDL_GetPerformanceFrequency();
-
-        SDL_ShowCursor(SDL_DISABLE);
 
 	window = SDL_CreateWindow(
 		SYSTEM_WINDOW_NAME,

--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -261,6 +261,8 @@ int main(int argc, char *argv[]) {
 
 	perf_freq = SDL_GetPerformanceFrequency();
 
+        SDL_ShowCursor(SDL_DISABLE);
+
 	window = SDL_CreateWindow(
 		SYSTEM_WINDOW_NAME,
 		SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,


### PR DESCRIPTION
SDL2 shows a default cursor by default, which IMHO takes away from the immersiveness that this game wants to achieve.

This simply adds the standard SDL2 call to hide the mouse cursor when the game window is set to fullscreen.