### PR TITLE
[SDL2] Lower audio buffer size to prevent audio lag.

### DIFF
--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -253,7 +253,7 @@ int main(int argc, char *argv[]) {
 		.freq = 44100,
 		.format = AUDIO_F32,
 		.channels = 2,
-		.samples = 4096,
+		.samples = 1024,
 		.callback = platform_audio_callback
 	}, NULL, 0);
 


### PR DESCRIPTION
Audio buffer of 4096 samples at 44KHz causes very noticeable audio delay.
This lowers the audio buffer size to 1024, which is a sane value and prevents that audio delay, thus making the game sound and video synchronization more akin to what could be seen and heard on PSX and DOS. 