### PR TITLE
Added support build on Windows under the MSYS2 enviroment.

### DIFF
--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -11,7 +11,8 @@
 // Linux
 #elif defined(__unix__)
 	#include <GL/glew.h>
-	
+#elif defined(__MSYS__)
+	#include <GL/glew.h>
 // WINDOWS
 #else
 	#include <windows.h>


### PR DESCRIPTION
Hi, I would like to propose this pull request to allow to build the game on Windows under the MSYS2 environment.

I tested on my machine with the installed tool-chain MINGW64 but in theory it must be able to build for all the supported tool-chains.  The dependencies can be installed using pacman tool.