### PR TITLE
Avoid rendering more than once those track sections in tracks with alternative paths.

### DIFF
--- a/src/wipeout/track.c
+++ b/src/wipeout/track.c
@@ -271,28 +271,14 @@ void track_draw(camera_t *camera) {
 	vec3_t cam_pos = camera->position;
 
 	section_t *s = g.track.sections;
-	section_t *j = NULL;
-	do {
+	for(int32_t i = 0; i < g.track.section_count; ++i, ++s)
+	{
 		vec3_t d = vec3_sub(cam_pos, s->center);
 		float dist_sq = d.x * d.x + d.y * d.y + d.z * d.z;
 		if (dist_sq <  max_dist_sq) {
 			track_draw_section(s);
 		}
-
-		if (s->junction) { // start junction
-			j = s->junction;
-			do {
-				vec3_t d = vec3_sub(cam_pos, j->center);
-				float dist_sq = d.x * d.x + d.y * d.y + d.z * d.z;
-				if (dist_sq <  max_dist_sq) {
-					track_draw_section(j);
-				}
-				j = j->next;
-			} while (!j->junction); // end junction
-		}
-		s = s->next;
-	} while (s != g.track.sections);
-	
+	}
 }
 
 void track_cycle_pickups() {


### PR DESCRIPTION
I found out the sections that comes from a junction are rendered more than once.  The original code, see below, traverses all the sections and when a junction is found it traverses it  (and all its sections chained) as well which was/will be traversed too.
````c++
	section_t *s = g.track.sections;
	section_t *j = NULL;
	do {
		vec3_t d = vec3_sub(cam_pos, s->center);
		float dist_sq = d.x * d.x + d.y * d.y + d.z * d.z;
		if (dist_sq <  max_dist_sq) {
			track_draw_section(s);
		}

		if (s->junction) { // start junction
			j = s->junction;
			do {
				vec3_t d = vec3_sub(cam_pos, j->center);
				float dist_sq = d.x * d.x + d.y * d.y + d.z * d.z;
				if (dist_sq <  max_dist_sq) {
					track_draw_section(j);
				}
				j = j->next;
			} while (!j->junction); // end junction
		}
		s = s->next;
	} while (s != g.track.sections);
````
This pull request basically simplifies the code by just traversing all the sections ignoring the junction link. I tested and I couldn't notice any issue and the amount of triangles rendered was reduced substantially. Circuits like SILVERSTREAM reduces the amount of triangles from around 1000 to 700.

I have an extra commit, not added to this pull request, which shows the amount of triangles rendered by the track. If you consider it useful I can included here as well.
