### PR TITLE
Change text of pause button to reflect dual function

### DIFF
--- a/src/wasm-index.html
+++ b/src/wasm-index.html
@@ -284,7 +284,9 @@
 			<div class="button button-pill" style="right: 14vw; bottom: 22vw" data-button="6"><div>br-l</div></div>
 
 			<div class="button button-pill" style="right: 2vw; top: 10vw" data-button="4"><div>view</div></div>
-			<div class="button button-pill" style="left: 68vw; top: 1vw" data-button="40"><div>pause</div></div>
+			<div class="button button-pill" style="left: 68vw; top: 1vw" data-button="40">
+				<div style="width: fit-content; padding-left: 30px; padding-right: 30px">pause/enter</div>
+			</div>
 		</div>
 			
 		</div>


### PR DESCRIPTION
I was trying out the touch controls on my phone and it works pretty well, but I found the name of the pause button confusing.

Unless there's a way to tell whether you're in menus (where the text should be `enter`) vs. in game (where it should be `pause`) I think we should reflect its dual use in the button text.