### PR TITLE
Add speed number in kph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /wipeout.sublime-project
 /wipeout.sublime-workspace
+.vscode
 
 /wipeout/
 /build/

--- a/src/wipeout/hud.c
+++ b/src/wipeout/hud.c
@@ -231,6 +231,10 @@ void hud_draw(ship_t *ship) {
 		: ship->speed;
 	hud_draw_speedo(speedo_speed, ship->thrust_mag);
 
+	// Current speed
+	ui_draw_number((int)ship->speed / 100, ui_scaled_pos(UI_POS_BOTTOM | UI_POS_RIGHT, vec2i(-140, -70)), UI_SIZE_16, UI_COLOR_DEFAULT);
+	ui_draw_text("KPH", ui_scaled_pos(UI_POS_BOTTOM | UI_POS_RIGHT, vec2i(-75, -70)), UI_SIZE_8, UI_COLOR_ACCENT);
+
 	// Weapon icon
 	if (ship->weapon_type != WEAPON_TYPE_NONE) {
 		vec2i_t pos = ui_scaled_pos(UI_POS_TOP | UI_POS_CENTER, vec2i(-16, 20));


### PR DESCRIPTION
I tried to match the display in Wipeout XL/2097 with what's available:

![image](https://github.com/phoboslab/wipeout-rewrite/assets/5837808/bb3d11b3-fdc7-4e0f-9a90-2fa3a875c1f4)

I'm not sure what the units are internally (dividing the ship speed by 100 seemed 'right').
