### PR TITLE
Correct pilots logo models drawn in main menu

### DIFF
--- a/src/wipeout/main_menu.c
+++ b/src/wipeout/main_menu.c
@@ -453,7 +453,7 @@ static void button_pilot_select(menu_t *menu, int data) {
 }
 
 static void page_pilot_draw(menu_t *menu, int data) {
-	draw_model(models.pilots[data], vec2(0, -0.2), vec3(0, 0, -10000), system_cycle_time());
+	draw_model(models.pilots[def.pilots[data].logo_model], vec2(0, -0.2), vec3(0, 0, -10000), system_cycle_time());
 }
 
 static void page_pilot_init(menu_t *menu) {


### PR DESCRIPTION
Launching the game from the latest version of the repository + the data files provided in the blog led to the wrong models being drawn in the pilot select screen.
To fix it, the index of the model to draw is taken from the game definitions.