### PR TITLE
Option to lessen internal camera roll

### DIFF
--- a/src/wipeout/camera.c
+++ b/src/wipeout/camera.c
@@ -10,6 +10,7 @@
 #include "weapon.h"
 #include "droid.h"
 #include "camera.h"
+#include "game.h"
 
 void camera_init(camera_t *camera, section_t *section) {
 	camera->section = section;
@@ -61,7 +62,7 @@ void camera_update_race_external(camera_t *camera, ship_t *ship, droid_t *droid)
 void camera_update_race_internal(camera_t *camera, ship_t *ship, droid_t *droid) {
 	camera->section = ship->section;
 	camera->position = ship_cockpit(ship);
-	camera->angle = vec3(ship->angle.x, ship->angle.y, ship->angle.z);
+	camera->angle = vec3(ship->angle.x, ship->angle.y, ship->angle.z * save.internal_roll);
 }
 
 void camera_update_race_intro(camera_t *camera, ship_t *ship, droid_t *droid) {

--- a/src/wipeout/game.c
+++ b/src/wipeout/game.c
@@ -396,6 +396,7 @@ save_t save = {
 
 	.sfx_volume = 0.6,
 	.music_volume = 0.5,
+	.internal_roll = 0.6,
 	.ui_scale = 0,
 	.show_fps = false,
 	.fullscreen = false,

--- a/src/wipeout/game.h
+++ b/src/wipeout/game.h
@@ -240,6 +240,7 @@ typedef struct {
 
 	float sfx_volume;
 	float music_volume;
+	float internal_roll;
 	uint8_t ui_scale;
 	bool show_fps;
 	bool fullscreen;

--- a/src/wipeout/main_menu.c
+++ b/src/wipeout/main_menu.c
@@ -260,6 +260,11 @@ static void toggle_fullscreen(menu_t *menu, int data) {
 	platform_set_fullscreen(save.fullscreen);
 }
 
+static void toggle_internal_roll(menu_t *menu, int data) {
+	save.internal_roll = (float)data * 0.1;
+	save.is_dirty = true;
+}
+
 static void toggle_show_fps(menu_t *menu, int data) {
 	save.show_fps = data;
 	save.is_dirty = true;
@@ -283,6 +288,7 @@ static void toggle_post(menu_t *menu, int data) {
 }
 
 static const char *opts_off_on[] = {"OFF", "ON"};
+static const char *opts_roll[] = {"0", "10", "20", "30", "40", "50", "60", "70", "80", "90", "100"};
 static const char *opts_ui_sizes[] = {"AUTO", "1X", "2X", "3X", "4X"};
 static const char *opts_res[] = {"NATIVE", "240P", "480P"};
 static const char *opts_post[] = {"NONE", "CRT EFFECT"};
@@ -299,6 +305,7 @@ static void page_options_video_init(menu_t *menu) {
 	#ifndef __EMSCRIPTEN__
 		menu_page_add_toggle(page, save.fullscreen, "FULLSCREEN", opts_off_on, len(opts_off_on), toggle_fullscreen);
 	#endif
+	menu_page_add_toggle(page, save.internal_roll * 10, "INTERNAL VIEW ROLL", opts_roll, len(opts_roll), toggle_internal_roll);
 	menu_page_add_toggle(page, save.ui_scale, "UI SCALE", opts_ui_sizes, len(opts_ui_sizes), toggle_ui_scale);
 	menu_page_add_toggle(page, save.show_fps, "SHOW FPS", opts_off_on, len(opts_off_on), toggle_show_fps);
 	menu_page_add_toggle(page, save.screen_res, "SCREEN RESOLUTION", opts_res, len(opts_res), toggle_res);


### PR DESCRIPTION
I took the most straightforward approach to lessen the internal camera roll using a new variable in save_t.
In the options, the value can be set from 0% to 100% of the original roll.
The default value is 60%, which makes the internal view much more enjoyable.
I had the idea to make 50% the minimum value, because values below 50% are a bit weird to play,
but I'll leave the decision to you.
Let me know if I overlooked something.