### PR TITLE
added initial wasm gamepad support for ds4

### DIFF
--- a/src/wasm-index.html
+++ b/src/wasm-index.html
@@ -245,6 +245,7 @@
 				<span class="key"><kbd>C</kbd> brake left</span>
 				<span class="key"><kbd>V</kbd> brake right</span>
 				<span class="key"><kbd>A</kbd> view</span>
+				<span id="gamepads"></span>
 			</div>
 			<div>
 				Read: 
@@ -342,6 +343,73 @@
 						});
 					}
 				}
+				// detect and setup gamepad
+				var activeGamepad;
+				var activeGamepadIndex;
+
+				const gamepadArray = [{
+					"gamepadName":"DualShock 4",
+					"regex":"(054c)(.*09cc)" ,
+					"pause":9,	//option
+					"view":3,	//triangle
+					"leftBrake":6,	//l2
+					"rightBrake":7,	//r2
+					"accelerate":0,	//x
+					"item":1,	//o
+					"up":12,
+					"down":13,
+					"left":14,
+					"right":15
+				},
+				{
+					"gamepadName":"DualShock 4",
+					"regex":"(android)" ,
+					"pause":9,	//option
+					"view":3,	//triangle
+					"leftBrake":6,	//l2
+					"rightBrake":7,	//r2
+					"accelerate":0,	//x
+					"item":1,	//o
+					"up":12,
+					"down":13,
+					"left":14,
+					"right":15
+
+				}
+				];
+
+				window.addEventListener("gamepadconnected", (event) => {
+				        mapGamepad(event.gamepad);
+				});
+
+				function mapGamepad(gamepad){
+					gamepadArray.forEach((detectedGamepad, index) => {
+						if (gamepad.id.match(new RegExp(detectedGamepad.regex, "g", "i"))){
+							activeGamepad = detectedGamepad;
+		                                        document.body.classList.remove('touch');
+						}
+					});
+					activeGamepadIndex = gamepad.index;
+					document.getElementById("gamepads").innerHTML = "Gamepad: " +activeGamepad.gamepadName;
+				        pollGamepad(gamepad);
+				};
+
+				function pollGamepad(gamepad){
+					Module._set_button(40, gamepad.buttons[activeGamepad.pause].value);
+					Module._set_button(4, gamepad.buttons[activeGamepad.view].value);
+					Module._set_button(6, gamepad.buttons[activeGamepad.leftBrake].value);
+					Module._set_button(25, gamepad.buttons[activeGamepad.rightBrake].value);
+					Module._set_button(27, gamepad.buttons[activeGamepad.accelerate].value);
+					Module._set_button(29, gamepad.buttons[activeGamepad.item].value);
+					Module._set_button(82, gamepad.buttons[activeGamepad.up].value);
+					Module._set_button(81, gamepad.buttons[activeGamepad.down].value);
+					Module._set_button(80, gamepad.buttons[activeGamepad.left].value);
+					Module._set_button(79, gamepad.buttons[activeGamepad.right].value);
+				        gamepad = navigator.getGamepads()[activeGamepadIndex];
+				        setTimeout(pollGamepad, 5, gamepad);
+                                };
+
+
 			};
 
 			var Module = {


### PR DESCRIPTION
This patch adds gamepad support for the WASM build using the JS gamepad api, per issue #39.
Initial support is for the DualShock 4, but other gamepads should be addable as well.
On firefox for android (and perhaps others) the gamepad.id is just set to "android", making gamepad fingerprinting kind of impossible, so for now any gamepad with id:"android" is just assumed to be a DualShock 4.

This patch was tested and working on the following browsers:
ubuntu 20.04: firefox 130.0, chromium 128.0.6613.84 
android 14:  firefox 130.0, vanadium 128.0.6613.99
