### PR TITLE
Use "sdl.h" include and sdl-config include path in makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DEBUG ?= false
 USER_CFLAGS ?=
 
 L_FLAGS ?= -lm
-C_FLAGS ?= -Isrc/libs/ -std=gnu99 -Wall -Wno-unused-variable $(USER_CFLAGS) $(shell sdl2-config --cflags)
+C_FLAGS ?= -Isrc/libs/ -std=gnu99 -Wall -Wno-unused-variable $(USER_CFLAGS)
 
 ifeq ($(DEBUG), true)
 	C_FLAGS := $(C_FLAGS) -g
@@ -133,6 +133,7 @@ COMMON_SRC = \
 COMMON_OBJ = $(patsubst %.c, $(BUILD_DIR)/%.o, $(COMMON_SRC))
 COMMON_DEPS = $(patsubst %.c, $(BUILD_DIR)/%.d, $(COMMON_SRC))
 
+sdl: C_FLAGS += $(shell sdl2-config --cflags)
 sdl: $(BUILD_DIR)/src/platform_sdl.o
 sdl: $(COMMON_OBJ)
 	$(CC) $^ -o $(TARGET_NATIVE) $(L_FLAGS) $(L_FLAGS_SDL)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DEBUG ?= false
 USER_CFLAGS ?=
 
 L_FLAGS ?= -lm
-C_FLAGS ?= -Isrc/libs/ -std=gnu99 -Wall -Wno-unused-variable $(USER_CFLAGS)
+C_FLAGS ?= -Isrc/libs/ -std=gnu99 -Wall -Wno-unused-variable $(USER_CFLAGS) $(shell sdl2-config --cflags)
 
 ifeq ($(DEBUG), true)
 	C_FLAGS := $(C_FLAGS) -g

--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include "SDL.h"
 
 #include "platform.h"
 #include "input.h"


### PR DESCRIPTION
Re: the discussion in https://github.com/phoboslab/wipeout-rewrite/issues/99#issuecomment-2449652016

I've made the changes to the Makefile and platform_sdl, which should fix the Cmake build error seen on Mac OS.

Tested only on MacOS Sonoma. Both the make and cmake commands result in a native build.

I've no access to a Windows or Linux box to test this, so may be worth a quick check that it doesn't break those builds.