### PR TITLE
clear weapon_target in ship_init (fixes #141)

### DIFF
--- a/src/wipeout/ship.c
+++ b/src/wipeout/ship.c
@@ -212,6 +212,7 @@ void ship_init(ship_t *self, section_t *section, int pilot, int inv_start_rank) 
 	self->ebolt_timer = 0;
 	self->revcon_timer = 0;
 	self->special_timer = 0;
+	self->weapon_target = NULL;
 	self->mat = mat4_identity();
 
 	self->update_timer = 0;


### PR DESCRIPTION
Target lock-on indicator state doesn't clear if you exit a race while locked-on to an enemy ship. This resolves that by clearing `weapon_target` field during `ship_init`.