### PR TITLE
WIP fix for ship-track collision behavior

### DIFF
--- a/src/wipeout/ship.c
+++ b/src/wipeout/ship.c
@@ -668,7 +668,7 @@ void ship_resolve_nose_collision(ship_t *self, track_face_t *face, float directi
 	self->velocity = vec3_sub(self->velocity, vec3_mulf(self->velocity, 0.5));
 	self->velocity = vec3_add(self->velocity, vec3_mulf(face->normal, 4096)); // div by 4096?
 
-	float magnitude = ((self->speed * 0.0625) + 400) * M_PI / (4096.0 * 64.0);
+	float magnitude = ((self->speed * 0.0625) + 400) * M_PI / 4096.0;
 	if (direction > 0) {
 		self->angular_velocity.y += magnitude;
 	}

--- a/src/wipeout/ship.c
+++ b/src/wipeout/ship.c
@@ -639,9 +639,9 @@ void ship_resolve_wing_collision(ship_t *self, track_face_t *face, float directi
 	self->velocity = vec3_reflect(self->velocity, face->normal, 2);
 	self->position = vec3_sub(self->position, vec3_mulf(self->velocity, 0.015625)); // system_tick?
 	self->velocity = vec3_sub(self->velocity, vec3_mulf(self->velocity, 0.5));
-	self->velocity = vec3_add(self->velocity, vec3_mulf(face->normal, 4096)); // div by 4096?
+	self->velocity = vec3_add(self->velocity, vec3_mulf(face->normal, 4096.0)); // div by 4096?
 
-	float magnitude = (fabsf(angle) * self->speed) * M_PI / (4096 * 16.0); // (6 velocity shift, 12 angle shift?)
+	float magnitude = (fabsf(angle) * self->speed) * M_PI / 4096.0; // (6 velocity shift, 12 angle shift?)
 
 	vec3_t wing_pos;
 	if (direction > 0) {

--- a/src/wipeout/ship.c
+++ b/src/wipeout/ship.c
@@ -630,7 +630,7 @@ static bool vec3_is_on_face(vec3_t pos, track_face_t *face, float alpha) {
 		vec3_angle(vec3, vec1) +
 		vec3_angle(vec1, vec0);
 
-	return (angle > M_PI * 2 - 0.01);
+	return (angle > ((30000/32767) * M_PI * 2));
 }
 
 void ship_resolve_wing_collision(ship_t *self, track_face_t *face, float direction) {

--- a/src/wipeout/ship.c
+++ b/src/wipeout/ship.c
@@ -630,7 +630,7 @@ static bool vec3_is_on_face(vec3_t pos, track_face_t *face, float alpha) {
 		vec3_angle(vec3, vec1) +
 		vec3_angle(vec1, vec0);
 
-	return (angle > ((30000/32767) * M_PI * 2));
+	return (angle > (0.91552734375 * M_PI * 2));
 }
 
 void ship_resolve_wing_collision(ship_t *self, track_face_t *face, float direction) {

--- a/src/wipeout/ship.c
+++ b/src/wipeout/ship.c
@@ -641,7 +641,7 @@ void ship_resolve_wing_collision(ship_t *self, track_face_t *face, float directi
 	self->velocity = vec3_sub(self->velocity, vec3_mulf(self->velocity, 0.5));
 	self->velocity = vec3_add(self->velocity, vec3_mulf(face->normal, 4096.0)); // div by 4096?
 
-	float magnitude = (fabsf(angle) * self->speed) * M_PI / 4096.0; // (6 velocity shift, 12 angle shift?)
+	float magnitude = (fabsf(angle) * self->speed) * 2 * M_PI / 4096.0; // (6 velocity shift, 12 angle shift?)
 
 	vec3_t wing_pos;
 	if (direction > 0) {
@@ -668,7 +668,7 @@ void ship_resolve_nose_collision(ship_t *self, track_face_t *face, float directi
 	self->velocity = vec3_sub(self->velocity, vec3_mulf(self->velocity, 0.5));
 	self->velocity = vec3_add(self->velocity, vec3_mulf(face->normal, 4096)); // div by 4096?
 
-	float magnitude = ((self->speed * 0.0625) + 400) * M_PI / 4096.0;
+	float magnitude = ((self->speed * 0.0625) + 400) * 2 * M_PI / 4096.0;
 	if (direction > 0) {
 		self->angular_velocity.y += magnitude;
 	}

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -347,7 +347,7 @@ void ship_player_update_race(ship_t *self) {
 			}
 			self->velocity = vec3_reflect(self->velocity, face->normal, 2);
 			self->velocity = vec3_sub(self->velocity, vec3_mulf(self->velocity, 0.125));
-			self->velocity = vec3_sub(self->velocity, face->normal);
+			self->velocity = vec3_sub(self->velocity, vec3_mulf(face->normal, 4096.0 * 30 * system_tick()));
 		}
 		else if (height < 30) {
 			self->velocity = vec3_add(self->velocity, vec3_mulf(face->normal, 4096.0 * 30 * system_tick()));

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -316,7 +316,7 @@ void ship_player_update_race(ship_t *self) {
 			vec3_angle(vec2, vec3) +
 			vec3_angle(vec3, vec1) +
 			vec3_angle(vec1, vec0);
-		if (angle < M_PI * 2 - 0.01) {
+		if (angle < (0.91552734375 * M_PI * 2)) {
 			flags_add(self->flags, SHIP_FLYING);
 		}
 	}

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -434,7 +434,7 @@ void ship_player_update_race(ship_t *self) {
 	self->position = vec3_add(self->position, vec3_mulf(self->velocity, 0.015625 * 30 * system_tick()));
 
 	self->angular_acceleration.x -= self->angular_velocity.x * 0.25 * 30;
-	self->angular_acceleration.z += ((0.03125 * self->angular_velocity.y) - (0.5 * self->angular_velocity.z)) * 30;
+	self->angular_acceleration.z += (self->angular_velocity.y - (0.5 * self->angular_velocity.z)) * 30;
 
 	// Orientation
 	if (self->angular_acceleration.y == 0) {

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -434,8 +434,7 @@ void ship_player_update_race(ship_t *self) {
 	self->position = vec3_add(self->position, vec3_mulf(self->velocity, 0.015625 * 30 * system_tick()));
 
 	self->angular_acceleration.x -= self->angular_velocity.x * 0.25 * 30;
-	self->angular_acceleration.z += (self->angular_velocity.y - 0.5 * self->angular_velocity.z) * 30;
-
+	self->angular_acceleration.z += ((0.03125 * self->angular_velocity.y) - (0.5 * self->angular_velocity.z)) * 30;
 
 	// Orientation
 	if (self->angular_acceleration.y == 0) {

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -471,16 +471,16 @@ void ship_player_update_rescue(ship_t *self) {
 	section_t *next = self->section->next;
 
 	if (flags_is(self->flags, SHIP_IN_TOW)) {
-		self->temp_target = vec3_add(self->temp_target, vec3_mulf(vec3_sub(next->center, self->temp_target), 0.0078125));
+		self->temp_target = vec3_add(self->temp_target, vec3_mulf(vec3_sub(next->center, self->temp_target), 0.0078125)); // >> 7
 		self->velocity = vec3_sub(self->temp_target, self->position);
 		vec3_t target_dir = vec3_sub(next->center, self->section->center);
 
-		self->angular_velocity.y = wrap_angle(-atan2(target_dir.x, target_dir.z) - self->angle.y) * (1.0/16.0) * 30;
+		self->angular_velocity.y = wrap_angle(-atan2(target_dir.x, target_dir.z) - self->angle.y) * 0.015625 * 30; // >> 6
 		self->angle.y = wrap_angle(self->angle.y + self->angular_velocity.y * system_tick());
 	}
 
-	self->angle.x -= self->angle.x * 0.125 * 30 * system_tick();
-	self->angle.z -= self->angle.z * 0.03125 * 30 * system_tick();
+	self->angle.x -= self->angle.x * 0.125 * 30 * system_tick(); // >> 3
+	self->angle.z -= self->angle.z * 0.03125 * 30 * system_tick(); // >> 5
 
 	self->velocity = vec3_sub(self->velocity, vec3_mulf(self->velocity, 0.0625 * 30 * system_tick()));
 	self->position = vec3_add(self->position, vec3_mulf(self->velocity, 0.03125 * 30 * system_tick()));

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -347,10 +347,10 @@ void ship_player_update_race(ship_t *self) {
 			}
 			self->velocity = vec3_reflect(self->velocity, face->normal, 2);
 			self->velocity = vec3_sub(self->velocity, vec3_mulf(self->velocity, 0.125));
-			self->velocity = vec3_sub(self->velocity, vec3_mulf(face->normal, 4096.0 * 30 * system_tick()));
+			self->velocity = vec3_sub(self->velocity, vec3_mulf(face->normal, 64.0 * 30 * system_tick()));
 		}
 		else if (height < 30) {
-			self->velocity = vec3_add(self->velocity, vec3_mulf(face->normal, 4096.0 * 30 * system_tick()));
+			self->velocity = vec3_add(self->velocity, vec3_mulf(face->normal, 64.0 * 30 * system_tick()));
 		}
 
 		if (height < 50) {


### PR DESCRIPTION
As discussed in #138 , there are multiple issues with the accuracy of the ship-track collision behavior.

It appears most of these stem from minor fixed-to-float conversion issues from the original code.

This is a work-in-progress fix for these issues and restores much of the expected behavior.

The `roll when wing hits side of track` seems a bit too sensitive at the moment, so more investigation is needed.