### PR TITLE
implement single/double sided poly state in object_draw (fix #150)

### DIFF
--- a/src/render.h
+++ b/src/render.h
@@ -46,6 +46,7 @@ void render_set_depth_test(bool enabled);
 void render_set_depth_offset(float offset);
 void render_set_screen_position(vec2_t pos);
 void render_set_blend_mode(render_blend_mode_t mode);
+void render_set_cull_backface(bool enabled);
 
 vec3_t render_transform(vec3_t pos);
 void render_push_tris(tris_t tris, uint16_t texture);

--- a/src/render.h
+++ b/src/render.h
@@ -46,11 +46,10 @@ void render_set_depth_test(bool enabled);
 void render_set_depth_offset(float offset);
 void render_set_screen_position(vec2_t pos);
 void render_set_blend_mode(render_blend_mode_t mode);
-void render_set_cull_backface(bool enabled);
 
 vec3_t render_transform(vec3_t pos);
 void render_push_tris(tris_t tris, uint16_t texture);
-void render_push_sprite(vec3_t pos, vec2i_t size, rgba_t color, uint16_t texture);
+void render_push_sprite(vec3_t pos, vec2i_t size, rgba_t color, uint16_t texture, int16_t prm_flag);
 void render_push_2d(vec2i_t pos, vec2i_t size, rgba_t color, uint16_t texture);
 void render_push_2d_tile(vec2i_t pos, vec2i_t uv_offset, vec2i_t uv_size, vec2i_t size, rgba_t color, uint16_t texture_index);
 

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -721,6 +721,19 @@ void render_set_blend_mode(render_blend_mode_t new_mode) {
 	}
 }
 
+void render_set_cull_backface(bool enabled) {
+	render_flush();
+	if (enabled) {
+		glEnable(GL_CULL_FACE);
+	}
+	else {
+		glDisable(GL_CULL_FACE);
+	}
+}
+
+
+
+
 vec3_t render_transform(vec3_t pos) {
 	return vec3_transform(vec3_transform(pos, &view_mat), &projection_mat_3d);
 }

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -721,10 +721,7 @@ void render_set_blend_mode(render_blend_mode_t new_mode) {
 }
 
 void render_set_cull_backface(bool enabled) {
-	// this function gets called *many* times by object_draw
-	// leaving the flush enabled kills llvm-softpipe performance
-	// I am not sure about other drivers - jnmartin84
-	//render_flush();
+	render_flush();
 	if (enabled) {
 		glEnable(GL_CULL_FACE);
 	}

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -721,7 +721,10 @@ void render_set_blend_mode(render_blend_mode_t new_mode) {
 }
 
 void render_set_cull_backface(bool enabled) {
-	render_flush();
+	// this function gets called *many* times by object_draw
+	// leaving the flush enabled kills llvm-softpipe performance
+	// I am not sure about other drivers - jnmartin84
+	//render_flush();
 	if (enabled) {
 		glEnable(GL_CULL_FACE);
 	}

--- a/src/render_software.c
+++ b/src/render_software.c
@@ -123,6 +123,7 @@ void render_set_depth_test(bool enabled) {}
 void render_set_depth_offset(float offset) {}
 void render_set_screen_position(vec2_t pos) {}
 void render_set_blend_mode(render_blend_mode_t mode) {}
+void render_set_cull_backface(bool enabled) {}
 
 vec3_t render_transform(vec3_t pos) {
 	return vec3_transform(vec3_transform(pos, &view_mat), &projection_mat);

--- a/src/wipeout/object.c
+++ b/src/wipeout/object.c
@@ -462,321 +462,324 @@ void object_draw(Object *object, mat4_t *mat) {
 
 	render_set_model_mat(mat);
 
+	render_set_cull_backface(true);
 	for (int i = 0; i < primitives_len; i++) {
 		int coord0;
 		int coord1;
 		int coord2;
 		int coord3;
 
-		if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-			render_set_cull_backface(true);
-		}
-		else {
-			render_set_cull_backface(false);
-		}
-
 		switch (poly.primitive->type) {
 		case PRM_TYPE_GT3:
-			coord0 = poly.gt3->coords[0];
-			coord1 = poly.gt3->coords[1];
-			coord2 = poly.gt3->coords[2];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.gt3->coords[0];
+				coord1 = poly.gt3->coords[1];
+				coord2 = poly.gt3->coords[2];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt3->u2, poly.gt3->v2},
-						.color = poly.gt3->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt3->u1, poly.gt3->v1},
-						.color = poly.gt3->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.gt3->u0, poly.gt3->v0},
-						.color = poly.gt3->color[0]
-					},
-				}
-			}, poly.gt3->texture);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt3->u2, poly.gt3->v2},
+							.color = poly.gt3->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt3->u1, poly.gt3->v1},
+							.color = poly.gt3->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt3->u0, poly.gt3->v0},
+							.color = poly.gt3->color[0]
+						},
+					}
+				}, poly.gt3->texture);
+			}
 			poly.gt3 += 1;
 			break;
 
 		case PRM_TYPE_GT4:
-			coord0 = poly.gt4->coords[0];
-			coord1 = poly.gt4->coords[1];
-			coord2 = poly.gt4->coords[2];
-			coord3 = poly.gt4->coords[3];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.gt4->coords[0];
+				coord1 = poly.gt4->coords[1];
+				coord2 = poly.gt4->coords[2];
+				coord3 = poly.gt4->coords[3];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt4->u2, poly.gt4->v2},
-						.color = poly.gt4->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt4->u1, poly.gt4->v1},
-						.color = poly.gt4->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.gt4->u0, poly.gt4->v0},
-						.color = poly.gt4->color[0]
-					},
-				}
-			}, poly.gt4->texture);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt4->u2, poly.gt4->v2},
-						.color = poly.gt4->color[2]
-					},
-					{
-						.pos = vertex[coord3],
-						.uv = {poly.gt4->u3, poly.gt4->v3},
-						.color = poly.gt4->color[3]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt4->u1, poly.gt4->v1},
-						.color = poly.gt4->color[1]
-					},
-				}
-			}, poly.gt4->texture);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt4->u0, poly.gt4->v0},
+							.color = poly.gt4->color[0]
+						},
+					}
+				}, poly.gt4->texture);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+						{
+							.pos = vertex[coord3],
+							.uv = {poly.gt4->u3, poly.gt4->v3},
+							.color = poly.gt4->color[3]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+					}
+				}, poly.gt4->texture);
+			}
 			poly.gt4 += 1;
 			break;
 
 		case PRM_TYPE_FT3:
-			coord0 = poly.ft3->coords[0];
-			coord1 = poly.ft3->coords[1];
-			coord2 = poly.ft3->coords[2];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.ft3->coords[0];
+				coord1 = poly.ft3->coords[1];
+				coord2 = poly.ft3->coords[2];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft3->u2, poly.ft3->v2},
-						.color = poly.ft3->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft3->u1, poly.ft3->v1},
-						.color = poly.ft3->color
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.ft3->u0, poly.ft3->v0},
-						.color = poly.ft3->color
-					},
-				}
-			}, poly.ft3->texture);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft3->u2, poly.ft3->v2},
+							.color = poly.ft3->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft3->u1, poly.ft3->v1},
+							.color = poly.ft3->color
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.ft3->u0, poly.ft3->v0},
+							.color = poly.ft3->color
+						},
+					}
+				}, poly.ft3->texture);
+			}
 			poly.ft3 += 1;
 			break;
 
 		case PRM_TYPE_FT4:
-			coord0 = poly.ft4->coords[0];
-			coord1 = poly.ft4->coords[1];
-			coord2 = poly.ft4->coords[2];
-			coord3 = poly.ft4->coords[3];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.ft4->coords[0];
+				coord1 = poly.ft4->coords[1];
+				coord2 = poly.ft4->coords[2];
+				coord3 = poly.ft4->coords[3];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft4->u2, poly.ft4->v2},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft4->u1, poly.ft4->v1},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.ft4->u0, poly.ft4->v0},
-						.color = poly.ft4->color
-					},
-				}
-			}, poly.ft4->texture);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft4->u2, poly.ft4->v2},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord3],
-						.uv = {poly.ft4->u3, poly.ft4->v3},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft4->u1, poly.ft4->v1},
-						.color = poly.ft4->color
-					},
-				}
-			}, poly.ft4->texture);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft4->u2, poly.ft4->v2},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft4->u1, poly.ft4->v1},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.ft4->u0, poly.ft4->v0},
+							.color = poly.ft4->color
+						},
+					}
+				}, poly.ft4->texture);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft4->u2, poly.ft4->v2},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord3],
+							.uv = {poly.ft4->u3, poly.ft4->v3},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft4->u1, poly.ft4->v1},
+							.color = poly.ft4->color
+						},
+					}
+				}, poly.ft4->texture);
+			}
 			poly.ft4 += 1;
 			break;
 
 		case PRM_TYPE_G3:
-			coord0 = poly.g3->coords[0];
-			coord1 = poly.g3->coords[1];
-			coord2 = poly.g3->coords[2];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.g3->coords[0];
+				coord1 = poly.g3->coords[1];
+				coord2 = poly.g3->coords[2];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g3->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g3->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.g3->color[0]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g3->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g3->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.g3->color[0]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
 			poly.g3 += 1;
 			break;
 
 		case PRM_TYPE_G4:
-			coord0 = poly.g4->coords[0];
-			coord1 = poly.g4->coords[1];
-			coord2 = poly.g4->coords[2];
-			coord3 = poly.g4->coords[3];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.g4->coords[0];
+				coord1 = poly.g4->coords[1];
+				coord2 = poly.g4->coords[2];
+				coord3 = poly.g4->coords[3];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g4->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g4->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.g4->color[0]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g4->color[2]
-					},
-					{
-						.pos = vertex[coord3],
-						.color = poly.g4->color[3]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g4->color[1]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g4->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g4->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.g4->color[0]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g4->color[2]
+						},
+						{
+							.pos = vertex[coord3],
+							.color = poly.g4->color[3]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g4->color[1]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
 			poly.g4 += 1;
 			break;
 
 		case PRM_TYPE_F3:
-			coord0 = poly.f3->coords[0];
-			coord1 = poly.f3->coords[1];
-			coord2 = poly.f3->coords[2];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.f3->coords[0];
+				coord1 = poly.f3->coords[1];
+				coord2 = poly.f3->coords[2];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f3->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f3->color
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.f3->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f3->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f3->color
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.f3->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
 			poly.f3 += 1;
 			break;
 
 		case PRM_TYPE_F4:
-			coord0 = poly.f4->coords[0];
-			coord1 = poly.f4->coords[1];
-			coord2 = poly.f4->coords[2];
-			coord3 = poly.f4->coords[3];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.f4->coords[0];
+				coord1 = poly.f4->coords[1];
+				coord2 = poly.f4->coords[2];
+				coord3 = poly.f4->coords[3];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.f4->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord3],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f4->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.f4->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord3],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f4->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
 			poly.f4 += 1;
 			break;
 
 		case PRM_TYPE_TSPR:
 		case PRM_TYPE_BSPR:
-			coord0 = poly.spr->coord;
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.spr->coord;
 
-			render_push_sprite(
-				vec3(
-					vertex[coord0].x,
-					vertex[coord0].y + ((poly.primitive->type == PRM_TYPE_TSPR ? poly.spr->height : -poly.spr->height) >> 1),
-					vertex[coord0].z
-				),
-				vec2i(poly.spr->width, poly.spr->height),
-				poly.spr->color,
-				poly.spr->texture
-			);
-
+				render_push_sprite(
+					vec3(
+						vertex[coord0].x,
+						vertex[coord0].y + ((poly.primitive->type == PRM_TYPE_TSPR ? poly.spr->height : -poly.spr->height) >> 1),
+						vertex[coord0].z
+					),
+					vec2i(poly.spr->width, poly.spr->height),
+					poly.spr->color,
+					poly.spr->texture
+				);
+			}
 			poly.spr += 1;
 			break;
 
@@ -785,4 +788,334 @@ void object_draw(Object *object, mat4_t *mat) {
 
 		}
 	}
+
+	poly.primitive = object->primitives;
+	render_set_cull_backface(false);
+	for (int i = 0; i < primitives_len; i++) {
+		int coord0;
+		int coord1;
+		int coord2;
+		int coord3;
+
+		switch (poly.primitive->type) {
+		case PRM_TYPE_GT3:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.gt3->coords[0];
+				coord1 = poly.gt3->coords[1];
+				coord2 = poly.gt3->coords[2];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt3->u2, poly.gt3->v2},
+							.color = poly.gt3->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt3->u1, poly.gt3->v1},
+							.color = poly.gt3->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt3->u0, poly.gt3->v0},
+							.color = poly.gt3->color[0]
+						},
+					}
+				}, poly.gt3->texture);
+			}
+			poly.gt3 += 1;
+			break;
+
+		case PRM_TYPE_GT4:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.gt4->coords[0];
+				coord1 = poly.gt4->coords[1];
+				coord2 = poly.gt4->coords[2];
+				coord3 = poly.gt4->coords[3];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt4->u0, poly.gt4->v0},
+							.color = poly.gt4->color[0]
+						},
+					}
+				}, poly.gt4->texture);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+						{
+							.pos = vertex[coord3],
+							.uv = {poly.gt4->u3, poly.gt4->v3},
+							.color = poly.gt4->color[3]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+					}
+				}, poly.gt4->texture);
+			}
+			poly.gt4 += 1;
+			break;
+
+		case PRM_TYPE_FT3:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.ft3->coords[0];
+				coord1 = poly.ft3->coords[1];
+				coord2 = poly.ft3->coords[2];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft3->u2, poly.ft3->v2},
+							.color = poly.ft3->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft3->u1, poly.ft3->v1},
+							.color = poly.ft3->color
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.ft3->u0, poly.ft3->v0},
+							.color = poly.ft3->color
+						},
+					}
+				}, poly.ft3->texture);
+			}
+			poly.ft3 += 1;
+			break;
+
+		case PRM_TYPE_FT4:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.ft4->coords[0];
+				coord1 = poly.ft4->coords[1];
+				coord2 = poly.ft4->coords[2];
+				coord3 = poly.ft4->coords[3];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft4->u2, poly.ft4->v2},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft4->u1, poly.ft4->v1},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.ft4->u0, poly.ft4->v0},
+							.color = poly.ft4->color
+						},
+					}
+				}, poly.ft4->texture);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft4->u2, poly.ft4->v2},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord3],
+							.uv = {poly.ft4->u3, poly.ft4->v3},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft4->u1, poly.ft4->v1},
+							.color = poly.ft4->color
+						},
+					}
+				}, poly.ft4->texture);
+			}
+			poly.ft4 += 1;
+			break;
+
+		case PRM_TYPE_G3:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.g3->coords[0];
+				coord1 = poly.g3->coords[1];
+				coord2 = poly.g3->coords[2];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g3->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g3->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.g3->color[0]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
+			poly.g3 += 1;
+			break;
+
+		case PRM_TYPE_G4:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.g4->coords[0];
+				coord1 = poly.g4->coords[1];
+				coord2 = poly.g4->coords[2];
+				coord3 = poly.g4->coords[3];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g4->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g4->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.g4->color[0]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g4->color[2]
+						},
+						{
+							.pos = vertex[coord3],
+							.color = poly.g4->color[3]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g4->color[1]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
+			poly.g4 += 1;
+			break;
+
+		case PRM_TYPE_F3:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.f3->coords[0];
+				coord1 = poly.f3->coords[1];
+				coord2 = poly.f3->coords[2];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f3->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f3->color
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.f3->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
+			poly.f3 += 1;
+			break;
+
+		case PRM_TYPE_F4:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.f4->coords[0];
+				coord1 = poly.f4->coords[1];
+				coord2 = poly.f4->coords[2];
+				coord3 = poly.f4->coords[3];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.f4->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord3],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f4->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
+			poly.f4 += 1;
+			break;
+
+		case PRM_TYPE_TSPR:
+		case PRM_TYPE_BSPR:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.spr->coord;
+
+				render_push_sprite(
+					vec3(
+						vertex[coord0].x,
+						vertex[coord0].y + ((poly.primitive->type == PRM_TYPE_TSPR ? poly.spr->height : -poly.spr->height) >> 1),
+						vertex[coord0].z
+					),
+					vec2i(poly.spr->width, poly.spr->height),
+					poly.spr->color,
+					poly.spr->texture
+				);
+			}
+			poly.spr += 1;
+			break;
+
+		default:
+			break;
+
+		}
+	}
+
 }
+

--- a/src/wipeout/object.c
+++ b/src/wipeout/object.c
@@ -462,13 +462,19 @@ void object_draw(Object *object, mat4_t *mat) {
 
 	render_set_model_mat(mat);
 
-	// TODO: check for PRM_SINGLE_SIDED
-
 	for (int i = 0; i < primitives_len; i++) {
 		int coord0;
 		int coord1;
 		int coord2;
 		int coord3;
+
+		if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+			render_set_cull_backface(true);
+		}
+		else {
+			render_set_cull_backface(false);
+		}
+
 		switch (poly.primitive->type) {
 		case PRM_TYPE_GT3:
 			coord0 = poly.gt3->coords[0];

--- a/src/wipeout/object.c
+++ b/src/wipeout/object.c
@@ -27,12 +27,7 @@ Object *objects_load(char *name, texture_list_t tl) {
 	Object *prevObject = NULL;
 	uint32_t p = 0;
 
-	int total_double = 0;
-	int total_single = 0;
-
 	while (p < length) {
-		int count_singleface = 0;
-		int count_doubleface = 0;
 		Object *object = mem_bump(sizeof(Object));
 		if (prevObject) {
 			prevObject->next = object;
@@ -107,14 +102,6 @@ Object *objects_load(char *name, texture_list_t tl) {
 			Prm prm;
 			int16_t prm_type = get_i16(bytes, &p);
 			int16_t prm_flag = get_i16(bytes, &p);
-
-			if (flags_is(prm_flag, PRM_SINGLE_SIDED)) {
-				count_singleface++;
-				total_single++;
-			} else {
-				count_doubleface++;
-				total_double++;
-			}
 
 			switch (prm_type) {
 			case PRM_TYPE_F3:
@@ -457,107 +444,9 @@ Object *objects_load(char *name, texture_list_t tl) {
 				die("bad primitive type %x \n", prm_type);
 			} // switch
 
-			prm.f3->type = prm_type;
-			prm.f3->flag = prm_flag;
+			prm.primitive->type = prm_type;
+			prm.primitive->flag = prm_flag;
 		} // each prim
-
-		object->primitives_singleface_len = count_singleface;
-		object->primitives_doubleface_len = count_doubleface;
-		object->primitives_singleface = (Primitive **)mem_bump(sizeof(Primitive *) * count_singleface);
-		object->primitives_doubleface = (Primitive **)mem_bump(sizeof(Primitive *) * count_doubleface);
-		Prm poly = {.primitive = object->primitives};
-		int primitives_len = object->primitives_len;
-		int index_singleface = 0;
-		int index_doubleface = 0;
-		for (int i = 0; i < primitives_len; i++) {
-			switch (poly.primitive->type) {
-			case PRM_TYPE_GT3:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.gt3 += 1;
-				break;
-
-			case PRM_TYPE_GT4:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.gt4 += 1;
-				break;
-
-			case PRM_TYPE_FT3:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.ft3 += 1;
-				break;
-
-			case PRM_TYPE_FT4:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.ft4 += 1;
-				break;
-
-			case PRM_TYPE_G3:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.g3 += 1;
-				break;
-
-			case PRM_TYPE_G4:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.g4 += 1;
-				break;
-
-			case PRM_TYPE_F3:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.f3 += 1;
-				break;
-
-			case PRM_TYPE_F4:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.f4 += 1;
-				break;
-
-			case PRM_TYPE_TSPR:
-			case PRM_TYPE_BSPR:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.spr += 1;
-				break;
-
-			default:
-				break;
-
-			}	
-		}
 	} // each object
 
 	mem_temp_free(bytes);
@@ -568,15 +457,12 @@ Object *objects_load(char *name, texture_list_t tl) {
 void object_draw(Object *object, mat4_t *mat) {
 	vec3_t *vertex = object->vertices;
 
-	int singleface_len = object->primitives_singleface_len;
-	int doubleface_len = object->primitives_doubleface_len;
+	Prm poly = {.primitive = object->primitives};
+	int primitives_len = object->primitives_len;
 
 	render_set_model_mat(mat);
 
-	render_set_cull_backface(true);
-	Primitive **ppoly = object->primitives_singleface;
-	for (int i = 0; i < singleface_len; i++) {
-		Prm poly = {.primitive = ppoly[i]};
+	for (int i = 0; i < primitives_len; i++) {
 		int coord0;
 		int coord1;
 		int coord2;
@@ -607,6 +493,28 @@ void object_draw(Object *object, mat4_t *mat) {
 					},
 				}
 			}, poly.gt3->texture);
+
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt3->u0, poly.gt3->v0},
+							.color = poly.gt3->color[0]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt3->u1, poly.gt3->v1},
+							.color = poly.gt3->color[1]
+						},
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt3->u2, poly.gt3->v2},
+							.color = poly.gt3->color[2]
+						},
+					}
+				}, poly.gt3->texture);
+			}
 
 			poly.gt3 += 1;
 			break;
@@ -655,6 +563,47 @@ void object_draw(Object *object, mat4_t *mat) {
 					},
 				}
 			}, poly.gt4->texture);
+
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt4->u0, poly.gt4->v0},
+							.color = poly.gt4->color[0]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+					}
+				}, poly.gt4->texture);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+						{
+							.pos = vertex[coord3],
+							.uv = {poly.gt4->u3, poly.gt4->v3},
+							.color = poly.gt4->color[3]
+						},
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+					}
+				}, poly.gt4->texture);
+			}
 
 			poly.gt4 += 1;
 			break;
@@ -881,7 +830,8 @@ void object_draw(Object *object, mat4_t *mat) {
 				),
 				vec2i(poly.spr->width, poly.spr->height),
 				poly.spr->color,
-				poly.spr->texture
+				poly.spr->texture,
+				poly.primitive->flag
 			);
 
 			poly.spr += 1;
@@ -891,326 +841,6 @@ void object_draw(Object *object, mat4_t *mat) {
 			break;
 
 		}
-	}
-
-	render_set_cull_backface(false);
-	ppoly = object->primitives_doubleface;
-	for (int i = 0; i < doubleface_len; i++) {
-		Prm poly = {.primitive = ppoly[i]};
-		int coord0;
-		int coord1;
-		int coord2;
-		int coord3;
-
-		switch (poly.primitive->type) {
-		case PRM_TYPE_GT3:
-			coord0 = poly.gt3->coords[0];
-			coord1 = poly.gt3->coords[1];
-			coord2 = poly.gt3->coords[2];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt3->u2, poly.gt3->v2},
-						.color = poly.gt3->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt3->u1, poly.gt3->v1},
-						.color = poly.gt3->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.gt3->u0, poly.gt3->v0},
-						.color = poly.gt3->color[0]
-					},
-				}
-			}, poly.gt3->texture);
-
-			poly.gt3 += 1;
-			break;
-
-		case PRM_TYPE_GT4:
-			coord0 = poly.gt4->coords[0];
-			coord1 = poly.gt4->coords[1];
-			coord2 = poly.gt4->coords[2];
-			coord3 = poly.gt4->coords[3];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt4->u2, poly.gt4->v2},
-						.color = poly.gt4->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt4->u1, poly.gt4->v1},
-						.color = poly.gt4->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.gt4->u0, poly.gt4->v0},
-						.color = poly.gt4->color[0]
-					},
-				}
-			}, poly.gt4->texture);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt4->u2, poly.gt4->v2},
-						.color = poly.gt4->color[2]
-					},
-					{
-						.pos = vertex[coord3],
-						.uv = {poly.gt4->u3, poly.gt4->v3},
-						.color = poly.gt4->color[3]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt4->u1, poly.gt4->v1},
-						.color = poly.gt4->color[1]
-					},
-				}
-			}, poly.gt4->texture);
-
-			poly.gt4 += 1;
-			break;
-
-		case PRM_TYPE_FT3:
-			coord0 = poly.ft3->coords[0];
-			coord1 = poly.ft3->coords[1];
-			coord2 = poly.ft3->coords[2];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft3->u2, poly.ft3->v2},
-						.color = poly.ft3->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft3->u1, poly.ft3->v1},
-						.color = poly.ft3->color
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.ft3->u0, poly.ft3->v0},
-						.color = poly.ft3->color
-					},
-				}
-			}, poly.ft3->texture);
-
-			poly.ft3 += 1;
-			break;
-
-		case PRM_TYPE_FT4:
-			coord0 = poly.ft4->coords[0];
-			coord1 = poly.ft4->coords[1];
-			coord2 = poly.ft4->coords[2];
-			coord3 = poly.ft4->coords[3];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft4->u2, poly.ft4->v2},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft4->u1, poly.ft4->v1},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.ft4->u0, poly.ft4->v0},
-						.color = poly.ft4->color
-					},
-				}
-			}, poly.ft4->texture);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft4->u2, poly.ft4->v2},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord3],
-						.uv = {poly.ft4->u3, poly.ft4->v3},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft4->u1, poly.ft4->v1},
-						.color = poly.ft4->color
-					},
-				}
-			}, poly.ft4->texture);
-
-			poly.ft4 += 1;
-			break;
-
-		case PRM_TYPE_G3:
-			coord0 = poly.g3->coords[0];
-			coord1 = poly.g3->coords[1];
-			coord2 = poly.g3->coords[2];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g3->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g3->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.g3->color[0]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
-			poly.g3 += 1;
-			break;
-
-		case PRM_TYPE_G4:
-			coord0 = poly.g4->coords[0];
-			coord1 = poly.g4->coords[1];
-			coord2 = poly.g4->coords[2];
-			coord3 = poly.g4->coords[3];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g4->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g4->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.g4->color[0]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g4->color[2]
-					},
-					{
-						.pos = vertex[coord3],
-						.color = poly.g4->color[3]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g4->color[1]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
-			poly.g4 += 1;
-			break;
-
-		case PRM_TYPE_F3:
-			coord0 = poly.f3->coords[0];
-			coord1 = poly.f3->coords[1];
-			coord2 = poly.f3->coords[2];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f3->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f3->color
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.f3->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
-			poly.f3 += 1;
-			break;
-
-		case PRM_TYPE_F4:
-			coord0 = poly.f4->coords[0];
-			coord1 = poly.f4->coords[1];
-			coord2 = poly.f4->coords[2];
-			coord3 = poly.f4->coords[3];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.f4->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord3],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f4->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
-			poly.f4 += 1;
-			break;
-
-		case PRM_TYPE_TSPR:
-		case PRM_TYPE_BSPR:
-			coord0 = poly.spr->coord;
-
-			render_push_sprite(
-				vec3(
-					vertex[coord0].x,
-					vertex[coord0].y + ((poly.primitive->type == PRM_TYPE_TSPR ? poly.spr->height : -poly.spr->height) >> 1),
-					vertex[coord0].z
-				),
-				vec2i(poly.spr->width, poly.spr->height),
-				poly.spr->color,
-				poly.spr->texture
-			);
-
-			poly.spr += 1;
-			break;
-
-		default:
-			break;
-
-		}		
 	}
 }
 

--- a/src/wipeout/object.h
+++ b/src/wipeout/object.h
@@ -341,11 +341,6 @@ typedef struct Object {
 	int16_t primitives_len; // Number of Primitives
 	Primitive *primitives; // Pointer to Z Sort Primitives
 
-	int16_t primitives_singleface_len; // Number of Primitives
-	Primitive **primitives_singleface;
-	int16_t primitives_doubleface_len; // Number of Primitives
-	Primitive **primitives_doubleface;
-
 	vec3_t origin;
 	int32_t extent; // Flags for object characteristics
 	int16_t flags; // Next object in list

--- a/src/wipeout/object.h
+++ b/src/wipeout/object.h
@@ -10,6 +10,7 @@
 
 typedef struct Primitive {
 	int16_t type; // Type of Primitive
+	int16_t flag;
 } Primitive;
 
 

--- a/src/wipeout/object.h
+++ b/src/wipeout/object.h
@@ -341,6 +341,11 @@ typedef struct Object {
 	int16_t primitives_len; // Number of Primitives
 	Primitive *primitives; // Pointer to Z Sort Primitives
 
+	int16_t primitives_singleface_len; // Number of Primitives
+	Primitive **primitives_singleface;
+	int16_t primitives_doubleface_len; // Number of Primitives
+	Primitive **primitives_doubleface;
+
 	vec3_t origin;
 	int32_t extent; // Flags for object characteristics
 	int16_t flags; // Next object in list

--- a/src/wipeout/particle.c
+++ b/src/wipeout/particle.c
@@ -4,6 +4,7 @@
 #include "../render.h"
 
 #include "particle.h"
+#include "object.h"
 #include "image.h"
 
 static particle_t *particles;
@@ -45,7 +46,7 @@ void particles_draw(void) {
 
 	for (int i = 0; i < particles_active; i++) {
 		particle_t *p = &particles[i];
-		render_push_sprite(p->position, p->size, p->color, p->texture);
+		render_push_sprite(p->position, p->size, p->color, p->texture, PRM_SINGLE_SIDED);
 	}
 
 	render_set_depth_offset(0.0);

--- a/src/wipeout/race.c
+++ b/src/wipeout/race.c
@@ -106,10 +106,8 @@ void race_update(void) {
 	render_set_view(g.camera.position, g.camera.angle);
 	render_set_screen_position(g.camera.shake);
 
-	render_set_cull_backface(false);
 	scene_draw(&g.camera);
 	track_draw(&g.camera);
-	render_set_cull_backface(true);
 
 	ships_draw();
 	droid_draw(&g.droid);

--- a/src/wipeout/race.c
+++ b/src/wipeout/race.c
@@ -107,7 +107,9 @@ void race_update(void) {
 	render_set_screen_position(g.camera.shake);
 
 	scene_draw(&g.camera);
+	render_set_cull_backface(false);
 	track_draw(&g.camera);
+	render_set_cull_backface(true);
 
 	ships_draw();
 	droid_draw(&g.droid);


### PR DESCRIPTION
Linux build of `wipeout-rewrite` with proposed changes:
![Screenshot 2025-04-21 220012](https://github.com/user-attachments/assets/e88091b9-9e33-4a25-a4d8-1dce725bef44)
![Screenshot 2025-04-21 220119](https://github.com/user-attachments/assets/c472a6c6-4a7a-486f-ad6b-fdc830976b61)

One issue arose and that was the repeated `render_flush` calls by way of `render_set_cull_backface` were ruining performance to the point the game was unplayable in my test environment (Virtual Box, Ubuntu 22.04, VMWare SVGA3D driver/llvm-softpipe).

I have not been able to test it on another OpenGL environment.