### PR TITLE
Fix track image bleeding through ship engine area

### DIFF
--- a/src/render.h
+++ b/src/render.h
@@ -46,6 +46,7 @@ void render_set_depth_test(bool enabled);
 void render_set_depth_offset(float offset);
 void render_set_screen_position(vec2_t pos);
 void render_set_blend_mode(render_blend_mode_t mode);
+void render_set_cull_backface(bool enabled);
 
 vec3_t render_transform(vec3_t pos);
 void render_push_tris(tris_t tris, uint16_t texture);

--- a/src/render.h
+++ b/src/render.h
@@ -46,11 +46,10 @@ void render_set_depth_test(bool enabled);
 void render_set_depth_offset(float offset);
 void render_set_screen_position(vec2_t pos);
 void render_set_blend_mode(render_blend_mode_t mode);
-void render_set_cull_backface(bool enabled);
 
 vec3_t render_transform(vec3_t pos);
 void render_push_tris(tris_t tris, uint16_t texture);
-void render_push_sprite(vec3_t pos, vec2i_t size, rgba_t color, uint16_t texture);
+void render_push_sprite(vec3_t pos, vec2i_t size, rgba_t color, uint16_t texture, int16_t prm_flag);
 void render_push_2d(vec2i_t pos, vec2i_t size, rgba_t color, uint16_t texture);
 void render_push_2d_tile(vec2i_t pos, vec2i_t uv_offset, vec2i_t uv_size, vec2i_t size, rgba_t color, uint16_t texture_index);
 

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -721,6 +721,19 @@ void render_set_blend_mode(render_blend_mode_t new_mode) {
 	}
 }
 
+void render_set_cull_backface(bool enabled) {
+	render_flush();
+	if (enabled) {
+		glEnable(GL_CULL_FACE);
+	}
+	else {
+		glDisable(GL_CULL_FACE);
+	}
+}
+
+
+
+
 vec3_t render_transform(vec3_t pos) {
 	return vec3_transform(vec3_transform(pos, &view_mat), &projection_mat_3d);
 }

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -721,10 +721,7 @@ void render_set_blend_mode(render_blend_mode_t new_mode) {
 }
 
 void render_set_cull_backface(bool enabled) {
-	// this function gets called *many* times by object_draw
-	// leaving the flush enabled kills llvm-softpipe performance
-	// I am not sure about other drivers - jnmartin84
-	//render_flush();
+	render_flush();
 	if (enabled) {
 		glEnable(GL_CULL_FACE);
 	}

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -721,7 +721,10 @@ void render_set_blend_mode(render_blend_mode_t new_mode) {
 }
 
 void render_set_cull_backface(bool enabled) {
-	render_flush();
+	// this function gets called *many* times by object_draw
+	// leaving the flush enabled kills llvm-softpipe performance
+	// I am not sure about other drivers - jnmartin84
+	//render_flush();
 	if (enabled) {
 		glEnable(GL_CULL_FACE);
 	}

--- a/src/render_software.c
+++ b/src/render_software.c
@@ -123,6 +123,7 @@ void render_set_depth_test(bool enabled) {}
 void render_set_depth_offset(float offset) {}
 void render_set_screen_position(vec2_t pos) {}
 void render_set_blend_mode(render_blend_mode_t mode) {}
+void render_set_cull_backface(bool enabled) {}
 
 vec3_t render_transform(vec3_t pos) {
 	return vec3_transform(vec3_transform(pos, &view_mat), &projection_mat);

--- a/src/wipeout/object.c
+++ b/src/wipeout/object.c
@@ -462,321 +462,324 @@ void object_draw(Object *object, mat4_t *mat) {
 
 	render_set_model_mat(mat);
 
+	render_set_cull_backface(true);
 	for (int i = 0; i < primitives_len; i++) {
 		int coord0;
 		int coord1;
 		int coord2;
 		int coord3;
 
-		if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-			render_set_cull_backface(true);
-		}
-		else {
-			render_set_cull_backface(false);
-		}
-
 		switch (poly.primitive->type) {
 		case PRM_TYPE_GT3:
-			coord0 = poly.gt3->coords[0];
-			coord1 = poly.gt3->coords[1];
-			coord2 = poly.gt3->coords[2];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.gt3->coords[0];
+				coord1 = poly.gt3->coords[1];
+				coord2 = poly.gt3->coords[2];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt3->u2, poly.gt3->v2},
-						.color = poly.gt3->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt3->u1, poly.gt3->v1},
-						.color = poly.gt3->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.gt3->u0, poly.gt3->v0},
-						.color = poly.gt3->color[0]
-					},
-				}
-			}, poly.gt3->texture);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt3->u2, poly.gt3->v2},
+							.color = poly.gt3->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt3->u1, poly.gt3->v1},
+							.color = poly.gt3->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt3->u0, poly.gt3->v0},
+							.color = poly.gt3->color[0]
+						},
+					}
+				}, poly.gt3->texture);
+			}
 			poly.gt3 += 1;
 			break;
 
 		case PRM_TYPE_GT4:
-			coord0 = poly.gt4->coords[0];
-			coord1 = poly.gt4->coords[1];
-			coord2 = poly.gt4->coords[2];
-			coord3 = poly.gt4->coords[3];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.gt4->coords[0];
+				coord1 = poly.gt4->coords[1];
+				coord2 = poly.gt4->coords[2];
+				coord3 = poly.gt4->coords[3];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt4->u2, poly.gt4->v2},
-						.color = poly.gt4->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt4->u1, poly.gt4->v1},
-						.color = poly.gt4->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.gt4->u0, poly.gt4->v0},
-						.color = poly.gt4->color[0]
-					},
-				}
-			}, poly.gt4->texture);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt4->u2, poly.gt4->v2},
-						.color = poly.gt4->color[2]
-					},
-					{
-						.pos = vertex[coord3],
-						.uv = {poly.gt4->u3, poly.gt4->v3},
-						.color = poly.gt4->color[3]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt4->u1, poly.gt4->v1},
-						.color = poly.gt4->color[1]
-					},
-				}
-			}, poly.gt4->texture);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt4->u0, poly.gt4->v0},
+							.color = poly.gt4->color[0]
+						},
+					}
+				}, poly.gt4->texture);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+						{
+							.pos = vertex[coord3],
+							.uv = {poly.gt4->u3, poly.gt4->v3},
+							.color = poly.gt4->color[3]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+					}
+				}, poly.gt4->texture);
+			}
 			poly.gt4 += 1;
 			break;
 
 		case PRM_TYPE_FT3:
-			coord0 = poly.ft3->coords[0];
-			coord1 = poly.ft3->coords[1];
-			coord2 = poly.ft3->coords[2];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.ft3->coords[0];
+				coord1 = poly.ft3->coords[1];
+				coord2 = poly.ft3->coords[2];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft3->u2, poly.ft3->v2},
-						.color = poly.ft3->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft3->u1, poly.ft3->v1},
-						.color = poly.ft3->color
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.ft3->u0, poly.ft3->v0},
-						.color = poly.ft3->color
-					},
-				}
-			}, poly.ft3->texture);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft3->u2, poly.ft3->v2},
+							.color = poly.ft3->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft3->u1, poly.ft3->v1},
+							.color = poly.ft3->color
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.ft3->u0, poly.ft3->v0},
+							.color = poly.ft3->color
+						},
+					}
+				}, poly.ft3->texture);
+			}
 			poly.ft3 += 1;
 			break;
 
 		case PRM_TYPE_FT4:
-			coord0 = poly.ft4->coords[0];
-			coord1 = poly.ft4->coords[1];
-			coord2 = poly.ft4->coords[2];
-			coord3 = poly.ft4->coords[3];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.ft4->coords[0];
+				coord1 = poly.ft4->coords[1];
+				coord2 = poly.ft4->coords[2];
+				coord3 = poly.ft4->coords[3];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft4->u2, poly.ft4->v2},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft4->u1, poly.ft4->v1},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.ft4->u0, poly.ft4->v0},
-						.color = poly.ft4->color
-					},
-				}
-			}, poly.ft4->texture);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft4->u2, poly.ft4->v2},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord3],
-						.uv = {poly.ft4->u3, poly.ft4->v3},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft4->u1, poly.ft4->v1},
-						.color = poly.ft4->color
-					},
-				}
-			}, poly.ft4->texture);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft4->u2, poly.ft4->v2},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft4->u1, poly.ft4->v1},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.ft4->u0, poly.ft4->v0},
+							.color = poly.ft4->color
+						},
+					}
+				}, poly.ft4->texture);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft4->u2, poly.ft4->v2},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord3],
+							.uv = {poly.ft4->u3, poly.ft4->v3},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft4->u1, poly.ft4->v1},
+							.color = poly.ft4->color
+						},
+					}
+				}, poly.ft4->texture);
+			}
 			poly.ft4 += 1;
 			break;
 
 		case PRM_TYPE_G3:
-			coord0 = poly.g3->coords[0];
-			coord1 = poly.g3->coords[1];
-			coord2 = poly.g3->coords[2];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.g3->coords[0];
+				coord1 = poly.g3->coords[1];
+				coord2 = poly.g3->coords[2];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g3->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g3->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.g3->color[0]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g3->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g3->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.g3->color[0]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
 			poly.g3 += 1;
 			break;
 
 		case PRM_TYPE_G4:
-			coord0 = poly.g4->coords[0];
-			coord1 = poly.g4->coords[1];
-			coord2 = poly.g4->coords[2];
-			coord3 = poly.g4->coords[3];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.g4->coords[0];
+				coord1 = poly.g4->coords[1];
+				coord2 = poly.g4->coords[2];
+				coord3 = poly.g4->coords[3];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g4->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g4->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.g4->color[0]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g4->color[2]
-					},
-					{
-						.pos = vertex[coord3],
-						.color = poly.g4->color[3]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g4->color[1]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g4->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g4->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.g4->color[0]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g4->color[2]
+						},
+						{
+							.pos = vertex[coord3],
+							.color = poly.g4->color[3]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g4->color[1]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
 			poly.g4 += 1;
 			break;
 
 		case PRM_TYPE_F3:
-			coord0 = poly.f3->coords[0];
-			coord1 = poly.f3->coords[1];
-			coord2 = poly.f3->coords[2];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.f3->coords[0];
+				coord1 = poly.f3->coords[1];
+				coord2 = poly.f3->coords[2];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f3->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f3->color
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.f3->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f3->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f3->color
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.f3->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
 			poly.f3 += 1;
 			break;
 
 		case PRM_TYPE_F4:
-			coord0 = poly.f4->coords[0];
-			coord1 = poly.f4->coords[1];
-			coord2 = poly.f4->coords[2];
-			coord3 = poly.f4->coords[3];
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.f4->coords[0];
+				coord1 = poly.f4->coords[1];
+				coord2 = poly.f4->coords[2];
+				coord3 = poly.f4->coords[3];
 
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.f4->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord3],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f4->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.f4->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord3],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f4->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
 			poly.f4 += 1;
 			break;
 
 		case PRM_TYPE_TSPR:
 		case PRM_TYPE_BSPR:
-			coord0 = poly.spr->coord;
+			if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.spr->coord;
 
-			render_push_sprite(
-				vec3(
-					vertex[coord0].x,
-					vertex[coord0].y + ((poly.primitive->type == PRM_TYPE_TSPR ? poly.spr->height : -poly.spr->height) >> 1),
-					vertex[coord0].z
-				),
-				vec2i(poly.spr->width, poly.spr->height),
-				poly.spr->color,
-				poly.spr->texture
-			);
-
+				render_push_sprite(
+					vec3(
+						vertex[coord0].x,
+						vertex[coord0].y + ((poly.primitive->type == PRM_TYPE_TSPR ? poly.spr->height : -poly.spr->height) >> 1),
+						vertex[coord0].z
+					),
+					vec2i(poly.spr->width, poly.spr->height),
+					poly.spr->color,
+					poly.spr->texture
+				);
+			}
 			poly.spr += 1;
 			break;
 
@@ -785,4 +788,334 @@ void object_draw(Object *object, mat4_t *mat) {
 
 		}
 	}
+
+	poly.primitive = object->primitives;
+	render_set_cull_backface(false);
+	for (int i = 0; i < primitives_len; i++) {
+		int coord0;
+		int coord1;
+		int coord2;
+		int coord3;
+
+		switch (poly.primitive->type) {
+		case PRM_TYPE_GT3:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.gt3->coords[0];
+				coord1 = poly.gt3->coords[1];
+				coord2 = poly.gt3->coords[2];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt3->u2, poly.gt3->v2},
+							.color = poly.gt3->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt3->u1, poly.gt3->v1},
+							.color = poly.gt3->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt3->u0, poly.gt3->v0},
+							.color = poly.gt3->color[0]
+						},
+					}
+				}, poly.gt3->texture);
+			}
+			poly.gt3 += 1;
+			break;
+
+		case PRM_TYPE_GT4:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.gt4->coords[0];
+				coord1 = poly.gt4->coords[1];
+				coord2 = poly.gt4->coords[2];
+				coord3 = poly.gt4->coords[3];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt4->u0, poly.gt4->v0},
+							.color = poly.gt4->color[0]
+						},
+					}
+				}, poly.gt4->texture);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+						{
+							.pos = vertex[coord3],
+							.uv = {poly.gt4->u3, poly.gt4->v3},
+							.color = poly.gt4->color[3]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+					}
+				}, poly.gt4->texture);
+			}
+			poly.gt4 += 1;
+			break;
+
+		case PRM_TYPE_FT3:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.ft3->coords[0];
+				coord1 = poly.ft3->coords[1];
+				coord2 = poly.ft3->coords[2];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft3->u2, poly.ft3->v2},
+							.color = poly.ft3->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft3->u1, poly.ft3->v1},
+							.color = poly.ft3->color
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.ft3->u0, poly.ft3->v0},
+							.color = poly.ft3->color
+						},
+					}
+				}, poly.ft3->texture);
+			}
+			poly.ft3 += 1;
+			break;
+
+		case PRM_TYPE_FT4:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.ft4->coords[0];
+				coord1 = poly.ft4->coords[1];
+				coord2 = poly.ft4->coords[2];
+				coord3 = poly.ft4->coords[3];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft4->u2, poly.ft4->v2},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft4->u1, poly.ft4->v1},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.ft4->u0, poly.ft4->v0},
+							.color = poly.ft4->color
+						},
+					}
+				}, poly.ft4->texture);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.ft4->u2, poly.ft4->v2},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord3],
+							.uv = {poly.ft4->u3, poly.ft4->v3},
+							.color = poly.ft4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.ft4->u1, poly.ft4->v1},
+							.color = poly.ft4->color
+						},
+					}
+				}, poly.ft4->texture);
+			}
+			poly.ft4 += 1;
+			break;
+
+		case PRM_TYPE_G3:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.g3->coords[0];
+				coord1 = poly.g3->coords[1];
+				coord2 = poly.g3->coords[2];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g3->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g3->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.g3->color[0]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
+			poly.g3 += 1;
+			break;
+
+		case PRM_TYPE_G4:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.g4->coords[0];
+				coord1 = poly.g4->coords[1];
+				coord2 = poly.g4->coords[2];
+				coord3 = poly.g4->coords[3];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g4->color[2]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g4->color[1]
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.g4->color[0]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.g4->color[2]
+						},
+						{
+							.pos = vertex[coord3],
+							.color = poly.g4->color[3]
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.g4->color[1]
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
+			poly.g4 += 1;
+			break;
+
+		case PRM_TYPE_F3:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.f3->coords[0];
+				coord1 = poly.f3->coords[1];
+				coord2 = poly.f3->coords[2];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f3->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f3->color
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.f3->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
+			poly.f3 += 1;
+			break;
+
+		case PRM_TYPE_F4:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.f4->coords[0];
+				coord1 = poly.f4->coords[1];
+				coord2 = poly.f4->coords[2];
+				coord3 = poly.f4->coords[3];
+
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord0],
+							.color = poly.f4->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord2],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord3],
+							.color = poly.f4->color
+						},
+						{
+							.pos = vertex[coord1],
+							.color = poly.f4->color
+						},
+					}
+				}, RENDER_NO_TEXTURE);
+			}
+			poly.f4 += 1;
+			break;
+
+		case PRM_TYPE_TSPR:
+		case PRM_TYPE_BSPR:
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				coord0 = poly.spr->coord;
+
+				render_push_sprite(
+					vec3(
+						vertex[coord0].x,
+						vertex[coord0].y + ((poly.primitive->type == PRM_TYPE_TSPR ? poly.spr->height : -poly.spr->height) >> 1),
+						vertex[coord0].z
+					),
+					vec2i(poly.spr->width, poly.spr->height),
+					poly.spr->color,
+					poly.spr->texture
+				);
+			}
+			poly.spr += 1;
+			break;
+
+		default:
+			break;
+
+		}
+	}
+
 }
+

--- a/src/wipeout/object.c
+++ b/src/wipeout/object.c
@@ -462,13 +462,19 @@ void object_draw(Object *object, mat4_t *mat) {
 
 	render_set_model_mat(mat);
 
-	// TODO: check for PRM_SINGLE_SIDED
-
 	for (int i = 0; i < primitives_len; i++) {
 		int coord0;
 		int coord1;
 		int coord2;
 		int coord3;
+
+		if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+			render_set_cull_backface(true);
+		}
+		else {
+			render_set_cull_backface(false);
+		}
+
 		switch (poly.primitive->type) {
 		case PRM_TYPE_GT3:
 			coord0 = poly.gt3->coords[0];

--- a/src/wipeout/object.c
+++ b/src/wipeout/object.c
@@ -26,6 +26,7 @@ Object *objects_load(char *name, texture_list_t tl) {
 	Object *objectList = mem_mark();
 	Object *prevObject = NULL;
 	uint32_t p = 0;
+	uint32_t p_at_first_prim;
 
 	while (p < length) {
 		Object *object = mem_bump(sizeof(Object));
@@ -97,8 +98,16 @@ Object *objects_load(char *name, texture_list_t tl) {
 			p += 2; // padding
 		}
 
+		// do two iterations of primitives in `bytes`
+		// first pass gets everything that isn't flagged `PRM_SHIP_ENGINE`
+		// we need to rewind the pointer into bytes after
+		// second pass gets everything flagged `PRM_SHIP_ENGINE`
+		// putting them at the end of the list fixes #65
+		// (Track image bleeds through ship engine area)
+		p_at_first_prim = p;
 		object->primitives = mem_mark();
 		for (int i = 0; i < object->primitives_len; i++) {
+			int exhaust_skipped = 0;
 			Prm prm;
 			int16_t prm_type = get_i16(bytes, &p);
 			int16_t prm_flag = get_i16(bytes, &p);
@@ -123,23 +132,43 @@ Object *objects_load(char *name, texture_list_t tl) {
 				break;
 
 			case PRM_TYPE_FT3:
-				prm.ptr = mem_bump(sizeof(FT3));
-				prm.ft3->coords[0] = get_i16(bytes, &p);
-				prm.ft3->coords[1] = get_i16(bytes, &p);
-				prm.ft3->coords[2] = get_i16(bytes, &p);
+				if (flags_is(prm_flag, PRM_SHIP_ENGINE)) {
+					exhaust_skipped = 1;
+					// skip the `bytes` of the exhaust `FT3`
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
 
-				prm.ft3->texture = texture_from_list(tl, get_i16(bytes, &p));
-				prm.ft3->cba = get_i16(bytes, &p);
-				prm.ft3->tsb = get_i16(bytes, &p);
-				prm.ft3->u0 = get_i8(bytes, &p);
-				prm.ft3->v0 = get_i8(bytes, &p);
-				prm.ft3->u1 = get_i8(bytes, &p);
-				prm.ft3->v1 = get_i8(bytes, &p);
-				prm.ft3->u2 = get_i8(bytes, &p);
-				prm.ft3->v2 = get_i8(bytes, &p);
+					get_u16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i16(bytes, &p);
+					get_u32(bytes, &p);
+				} else {
+					prm.ptr = mem_bump(sizeof(FT3));
+					prm.ft3->coords[0] = get_i16(bytes, &p);
+					prm.ft3->coords[1] = get_i16(bytes, &p);
+					prm.ft3->coords[2] = get_i16(bytes, &p);
 
-				prm.ft3->pad1 = get_i16(bytes, &p);
-				prm.ft3->color = rgba_from_u32(get_u32(bytes, &p));
+					prm.ft3->texture = texture_from_list(tl, get_i16(bytes, &p));
+					prm.ft3->cba = get_i16(bytes, &p);
+					prm.ft3->tsb = get_i16(bytes, &p);
+					prm.ft3->u0 = get_i8(bytes, &p);
+					prm.ft3->v0 = get_i8(bytes, &p);
+					prm.ft3->u1 = get_i8(bytes, &p);
+					prm.ft3->v1 = get_i8(bytes, &p);
+					prm.ft3->u2 = get_i8(bytes, &p);
+					prm.ft3->v2 = get_i8(bytes, &p);
+
+					prm.ft3->pad1 = get_i16(bytes, &p);
+					prm.ft3->color = rgba_from_u32(get_u32(bytes, &p));
+				}
 				break;
 
 			case PRM_TYPE_FT4:
@@ -188,24 +217,46 @@ Object *objects_load(char *name, texture_list_t tl) {
 				break;
 
 			case PRM_TYPE_GT3:
-				prm.ptr = mem_bump(sizeof(GT3));
-				prm.gt3->coords[0] = get_i16(bytes, &p);
-				prm.gt3->coords[1] = get_i16(bytes, &p);
-				prm.gt3->coords[2] = get_i16(bytes, &p);
+				if (flags_is(prm_flag, PRM_SHIP_ENGINE)) {
+					exhaust_skipped = 1;
+					// skip the `bytes` of the exhaust `GT3`
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
 
-				prm.gt3->texture = texture_from_list(tl, get_i16(bytes, &p));
-				prm.gt3->cba = get_i16(bytes, &p);
-				prm.gt3->tsb = get_i16(bytes, &p);
-				prm.gt3->u0 = get_i8(bytes, &p);
-				prm.gt3->v0 = get_i8(bytes, &p);
-				prm.gt3->u1 = get_i8(bytes, &p);
-				prm.gt3->v1 = get_i8(bytes, &p);
-				prm.gt3->u2 = get_i8(bytes, &p);
-				prm.gt3->v2 = get_i8(bytes, &p);
-				prm.gt3->pad1 = get_i16(bytes, &p);
-				prm.gt3->color[0] = rgba_from_u32(get_u32(bytes, &p));
-				prm.gt3->color[1] = rgba_from_u32(get_u32(bytes, &p));
-				prm.gt3->color[2] = rgba_from_u32(get_u32(bytes, &p));
+					get_u16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i16(bytes, &p);
+					get_u32(bytes, &p);
+					get_u32(bytes, &p);
+					get_u32(bytes, &p);
+				} else {
+					prm.ptr = mem_bump(sizeof(GT3));
+					prm.gt3->coords[0] = get_i16(bytes, &p);
+					prm.gt3->coords[1] = get_i16(bytes, &p);
+					prm.gt3->coords[2] = get_i16(bytes, &p);
+
+					prm.gt3->texture = texture_from_list(tl, get_i16(bytes, &p));
+					prm.gt3->cba = get_i16(bytes, &p);
+					prm.gt3->tsb = get_i16(bytes, &p);
+					prm.gt3->u0 = get_i8(bytes, &p);
+					prm.gt3->v0 = get_i8(bytes, &p);
+					prm.gt3->u1 = get_i8(bytes, &p);
+					prm.gt3->v1 = get_i8(bytes, &p);
+					prm.gt3->u2 = get_i8(bytes, &p);
+					prm.gt3->v2 = get_i8(bytes, &p);
+					prm.gt3->pad1 = get_i16(bytes, &p);
+					prm.gt3->color[0] = rgba_from_u32(get_u32(bytes, &p));
+					prm.gt3->color[1] = rgba_from_u32(get_u32(bytes, &p));
+					prm.gt3->color[2] = rgba_from_u32(get_u32(bytes, &p));
+				}
 				break;
 
 			case PRM_TYPE_GT4:
@@ -444,8 +495,427 @@ Object *objects_load(char *name, texture_list_t tl) {
 				die("bad primitive type %x \n", prm_type);
 			} // switch
 
-			prm.primitive->type = prm_type;
-			prm.primitive->flag = prm_flag;
+			if (!exhaust_skipped) {
+				prm.primitive->type = prm_type;
+				prm.primitive->flag = prm_flag;
+			}
+		} // each prim
+
+		// set p back to start of primitives in `bytes`
+		p = p_at_first_prim;
+		for (int i = 0; i < object->primitives_len; i++) {
+			Prm prm;
+			int16_t prm_type = get_i16(bytes, &p);
+			int16_t prm_flag = get_i16(bytes, &p);
+			switch (prm_type) {
+			case PRM_TYPE_F3:
+				// skip `F3`
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_u32(bytes, &p);
+				break;
+
+			case PRM_TYPE_F4:
+				// skip `F4`
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_u32(bytes, &p);
+				break;
+
+			case PRM_TYPE_FT3:
+				// now add the exhaust `FT3`
+				if (flags_is(prm_flag, PRM_SHIP_ENGINE)) {
+					prm.ptr = mem_bump(sizeof(FT3));
+					prm.ft3->type = prm_type;
+					prm.ft3->flag = prm_flag;
+					prm.ft3->coords[0] = get_i16(bytes, &p);
+					prm.ft3->coords[1] = get_i16(bytes, &p);
+					prm.ft3->coords[2] = get_i16(bytes, &p);
+
+					prm.ft3->texture = texture_from_list(tl, get_u16(bytes, &p));
+					prm.ft3->cba = get_i16(bytes, &p);
+					prm.ft3->tsb = get_i16(bytes, &p);
+					prm.ft3->u0 = get_i8(bytes, &p);
+					prm.ft3->v0 = get_i8(bytes, &p);
+					prm.ft3->u1 = get_i8(bytes, &p);
+					prm.ft3->v1 = get_i8(bytes, &p);
+					prm.ft3->u2 = get_i8(bytes, &p);
+					prm.ft3->v2 = get_i8(bytes, &p);
+
+					prm.ft3->pad1 = get_i16(bytes, &p);
+					prm.ft3->color = rgba_from_u32(get_u32(bytes, &p));
+				} else {
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
+
+					get_u16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i16(bytes, &p);
+					get_u32(bytes, &p);
+				}
+				break;
+
+			case PRM_TYPE_FT4:
+				// skip `FT4`
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+
+				get_u16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i16(bytes, &p);
+				get_u32(bytes, &p);
+
+				break;
+
+			case PRM_TYPE_G3:
+				// skip `G3`
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_u32(bytes, &p);
+				get_u32(bytes, &p);
+				get_u32(bytes, &p);
+				break;
+
+			case PRM_TYPE_G4:
+				// skip `G4`
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_u32(bytes, &p);
+				get_u32(bytes, &p);
+				get_u32(bytes, &p);
+				get_u32(bytes, &p);
+				break;
+
+			case PRM_TYPE_GT3:
+				// now add the exhaust `GT3`
+				if (flags_is(prm_flag, PRM_SHIP_ENGINE)) {
+					prm.ptr = mem_bump(sizeof(GT3));
+					prm.gt3->type = prm_type;
+					prm.gt3->flag = prm_flag;
+					prm.gt3->coords[0] = get_i16(bytes, &p);
+					prm.gt3->coords[1] = get_i16(bytes, &p);
+					prm.gt3->coords[2] = get_i16(bytes, &p);
+
+					prm.gt3->texture = texture_from_list(tl, get_u16(bytes, &p));
+					prm.gt3->cba = get_i16(bytes, &p);
+					prm.gt3->tsb = get_i16(bytes, &p);
+					prm.gt3->u0 = get_i8(bytes, &p);
+					prm.gt3->v0 = get_i8(bytes, &p);
+					prm.gt3->u1 = get_i8(bytes, &p);
+					prm.gt3->v1 = get_i8(bytes, &p);
+					prm.gt3->u2 = get_i8(bytes, &p);
+					prm.gt3->v2 = get_i8(bytes, &p);
+					prm.gt3->pad1 = get_i16(bytes, &p);
+					prm.gt3->color[0] = rgba_from_u32(get_u32(bytes, &p));
+					prm.gt3->color[1] = rgba_from_u32(get_u32(bytes, &p));
+					prm.gt3->color[2] = rgba_from_u32(get_u32(bytes, &p));
+				} else {
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
+
+					get_u16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i16(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i8(bytes, &p);
+					get_i16(bytes, &p);
+					get_u32(bytes, &p);
+					get_u32(bytes, &p);
+					get_u32(bytes, &p);
+				}
+				break;
+
+			case PRM_TYPE_GT4:
+				// skip `GT4`
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+
+				get_u16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i8(bytes, &p);
+				get_i16(bytes, &p);
+				get_u32(bytes, &p);
+				get_u32(bytes, &p);
+				get_u32(bytes, &p);
+				get_u32(bytes, &p);
+
+				break;
+
+
+			case PRM_TYPE_TSPR:
+			case PRM_TYPE_BSPR:
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_i16(bytes, &p);
+				get_u32(bytes, &p);
+				break;
+
+			// I did not have patience to write code to skip things
+			// that don't actually exist in the Wipeout data
+
+/*			case PRM_TYPE_LSF3:
+				prm.ptr = mem_bump(sizeof(LSF3));
+				prm.lsf3->type = prm_type;
+				prm.lsf3->flag = prm_flag;
+				prm.lsf3->coords[0] = get_i16(bytes, &p);
+				prm.lsf3->coords[1] = get_i16(bytes, &p);
+				prm.lsf3->coords[2] = get_i16(bytes, &p);
+				prm.lsf3->normal = get_i16(bytes, &p);
+				prm.lsf3->color = argb_from_u32(get_u32(bytes, &p));
+				break;
+
+			case PRM_TYPE_LSF4:
+				prm.ptr = mem_bump(sizeof(LSF4));
+				prm.lsf4->type = prm_type;
+				prm.lsf4->flag = prm_flag;
+				prm.lsf4->coords[0] = get_i16(bytes, &p);
+				prm.lsf4->coords[1] = get_i16(bytes, &p);
+				prm.lsf4->coords[2] = get_i16(bytes, &p);
+				prm.lsf4->coords[3] = get_i16(bytes, &p);
+				prm.lsf4->normal = get_i16(bytes, &p);
+				prm.lsf4->pad1 = get_i16(bytes, &p);
+				prm.lsf4->color = argb_from_u32(get_u32(bytes, &p));
+				break;
+
+			case PRM_TYPE_LSFT3:
+				prm.ptr = mem_bump(sizeof(LSFT3));
+				prm.lsft3->type = prm_type;
+				prm.lsft3->flag = prm_flag;
+				prm.lsft3->coords[0] = get_i16(bytes, &p);
+				prm.lsft3->coords[1] = get_i16(bytes, &p);
+				prm.lsft3->coords[2] = get_i16(bytes, &p);
+				prm.lsft3->normal = get_i16(bytes, &p);
+
+				prm.lsft3->texture = texture_from_list(tl, get_i16(bytes, &p));
+				prm.lsft3->cba = get_i16(bytes, &p);
+				prm.lsft3->tsb = get_i16(bytes, &p);
+				prm.lsft3->u0 = get_i8(bytes, &p);
+				prm.lsft3->v0 = get_i8(bytes, &p);
+				prm.lsft3->u1 = get_i8(bytes, &p);
+				prm.lsft3->v1 = get_i8(bytes, &p);
+				prm.lsft3->u2 = get_i8(bytes, &p);
+				prm.lsft3->v2 = get_i8(bytes, &p);
+				prm.lsft3->color = argb_from_u32(get_u32(bytes, &p));
+				break;
+
+			case PRM_TYPE_LSFT4:
+				prm.ptr = mem_bump(sizeof(LSFT4));
+				prm.lsft4->type = prm_type;
+				prm.lsft4->flag = prm_flag;
+				prm.lsft4->coords[0] = get_i16(bytes, &p);
+				prm.lsft4->coords[1] = get_i16(bytes, &p);
+				prm.lsft4->coords[2] = get_i16(bytes, &p);
+				prm.lsft4->coords[3] = get_i16(bytes, &p);
+				prm.lsft4->normal = get_i16(bytes, &p);
+
+				prm.lsft4->texture = texture_from_list(tl, get_i16(bytes, &p));
+				prm.lsft4->cba = get_i16(bytes, &p);
+				prm.lsft4->tsb = get_i16(bytes, &p);
+				prm.lsft4->u0 = get_i8(bytes, &p);
+				prm.lsft4->v0 = get_i8(bytes, &p);
+				prm.lsft4->u1 = get_i8(bytes, &p);
+				prm.lsft4->v1 = get_i8(bytes, &p);
+				prm.lsft4->u2 = get_i8(bytes, &p);
+				prm.lsft4->v2 = get_i8(bytes, &p);
+				prm.lsft4->u3 = get_i8(bytes, &p);
+				prm.lsft4->v3 = get_i8(bytes, &p);
+				prm.lsft4->color = argb_from_u32(get_u32(bytes, &p));
+				break;
+
+			case PRM_TYPE_LSG3:
+				prm.ptr = mem_bump(sizeof(LSG3));
+				prm.lsg3->type = prm_type;
+				prm.lsg3->flag = prm_flag;
+				prm.lsg3->coords[0] = get_i16(bytes, &p);
+				prm.lsg3->coords[1] = get_i16(bytes, &p);
+				prm.lsg3->coords[2] = get_i16(bytes, &p);
+				prm.lsg3->normals[0] = get_i16(bytes, &p);
+				prm.lsg3->normals[1] = get_i16(bytes, &p);
+				prm.lsg3->normals[2] = get_i16(bytes, &p);
+				prm.lsg3->color[0] = argb_from_u32(get_u32(bytes, &p));
+				prm.lsg3->color[1] = argb_from_u32(get_u32(bytes, &p));
+				prm.lsg3->color[2] = argb_from_u32(get_u32(bytes, &p));
+				break;
+
+			case PRM_TYPE_LSG4:
+				prm.ptr = mem_bump(sizeof(LSG4));
+				prm.lsg4->type = prm_type;
+				prm.lsg4->flag = prm_flag;
+				prm.lsg4->coords[0] = get_i16(bytes, &p);
+				prm.lsg4->coords[1] = get_i16(bytes, &p);
+				prm.lsg4->coords[2] = get_i16(bytes, &p);
+				prm.lsg4->coords[3] = get_i16(bytes, &p);
+				prm.lsg4->normals[0] = get_i16(bytes, &p);
+				prm.lsg4->normals[1] = get_i16(bytes, &p);
+				prm.lsg4->normals[2] = get_i16(bytes, &p);
+				prm.lsg4->normals[3] = get_i16(bytes, &p);
+				prm.lsg4->color[0] = argb_from_u32(get_u32(bytes, &p));
+				prm.lsg4->color[1] = argb_from_u32(get_u32(bytes, &p));
+				prm.lsg4->color[2] = argb_from_u32(get_u32(bytes, &p));
+				prm.lsg4->color[3] = argb_from_u32(get_u32(bytes, &p));
+				break;
+
+			case PRM_TYPE_LSGT3:
+				prm.ptr = mem_bump(sizeof(LSGT3));
+				prm.lsgt3->type = prm_type;
+				prm.lsgt3->flag = prm_flag;
+				prm.lsgt3->coords[0] = get_i16(bytes, &p);
+				prm.lsgt3->coords[1] = get_i16(bytes, &p);
+				prm.lsgt3->coords[2] = get_i16(bytes, &p);
+				prm.lsgt3->normals[0] = get_i16(bytes, &p);
+				prm.lsgt3->normals[1] = get_i16(bytes, &p);
+				prm.lsgt3->normals[2] = get_i16(bytes, &p);
+
+				prm.lsgt3->texture = texture_from_list(tl, get_i16(bytes, &p));
+				prm.lsgt3->cba = get_i16(bytes, &p);
+				prm.lsgt3->tsb = get_i16(bytes, &p);
+				prm.lsgt3->u0 = get_i8(bytes, &p);
+				prm.lsgt3->v0 = get_i8(bytes, &p);
+				prm.lsgt3->u1 = get_i8(bytes, &p);
+				prm.lsgt3->v1 = get_i8(bytes, &p);
+				prm.lsgt3->u2 = get_i8(bytes, &p);
+				prm.lsgt3->v2 = get_i8(bytes, &p);
+				prm.lsgt3->color[0] = argb_from_u32(get_u32(bytes, &p));
+				prm.lsgt3->color[1] = argb_from_u32(get_u32(bytes, &p));
+				prm.lsgt3->color[2] = argb_from_u32(get_u32(bytes, &p));
+				break;
+
+			case PRM_TYPE_LSGT4:
+				prm.ptr = mem_bump(sizeof(LSGT4));
+				prm.lsgt4->type = prm_type;
+				prm.lsgt4->flag = prm_flag;
+				prm.lsgt4->coords[0] = get_i16(bytes, &p);
+				prm.lsgt4->coords[1] = get_i16(bytes, &p);
+				prm.lsgt4->coords[2] = get_i16(bytes, &p);
+				prm.lsgt4->coords[3] = get_i16(bytes, &p);
+				prm.lsgt4->normals[0] = get_i16(bytes, &p);
+				prm.lsgt4->normals[1] = get_i16(bytes, &p);
+				prm.lsgt4->normals[2] = get_i16(bytes, &p);
+				prm.lsgt4->normals[3] = get_i16(bytes, &p);
+
+				prm.lsgt4->texture = texture_from_list(tl, get_i16(bytes, &p));
+				prm.lsgt4->cba = get_i16(bytes, &p);
+				prm.lsgt4->tsb = get_i16(bytes, &p);
+				prm.lsgt4->u0 = get_i8(bytes, &p);
+				prm.lsgt4->v0 = get_i8(bytes, &p);
+				prm.lsgt4->u1 = get_i8(bytes, &p);
+				prm.lsgt4->v1 = get_i8(bytes, &p);
+				prm.lsgt4->u2 = get_i8(bytes, &p);
+				prm.lsgt4->v2 = get_i8(bytes, &p);
+				prm.lsgt4->pad1 = get_i16(bytes, &p);
+				prm.lsgt4->color[0] = argb_from_u32(get_u32(bytes, &p));
+				prm.lsgt4->color[1] = argb_from_u32(get_u32(bytes, &p));
+				prm.lsgt4->color[2] = argb_from_u32(get_u32(bytes, &p));
+				prm.lsgt4->color[3] = argb_from_u32(get_u32(bytes, &p));
+				break;
+
+ 			case PRM_TYPE_SPLINE:
+				prm.ptr = mem_bump(sizeof(Spline));
+				prm.spline->type = prm_type;
+				prm.spline->flag = prm_flag;
+				prm.spline->control1.x = get_i32(bytes, &p);
+				prm.spline->control1.y = get_i32(bytes, &p);
+				prm.spline->control1.z = get_i32(bytes, &p);
+				p += 4; // padding
+				prm.spline->position.x = get_i32(bytes, &p);
+				prm.spline->position.y = get_i32(bytes, &p);
+				prm.spline->position.z = get_i32(bytes, &p);
+				p += 4; // padding
+				prm.spline->control2.x = get_i32(bytes, &p);
+				prm.spline->control2.y = get_i32(bytes, &p);
+				prm.spline->control2.z = get_i32(bytes, &p);
+				p += 4; // padding
+				prm.spline->color = argb_from_u32(get_u32(bytes, &p));
+				break;
+
+			case PRM_TYPE_POINT_LIGHT:
+				prm.ptr = mem_bump(sizeof(PointLight));
+				prm.pointLight->type = prm_type;
+				prm.pointLight->flag = prm_flag;
+				prm.pointLight->position.x = get_i32(bytes, &p);
+				prm.pointLight->position.y = get_i32(bytes, &p);
+				prm.pointLight->position.z = get_i32(bytes, &p);
+				p += 4; // padding
+				prm.pointLight->color = argb_from_u32(get_u32(bytes, &p));
+				prm.pointLight->startFalloff = get_i16(bytes, &p);
+				prm.pointLight->endFalloff = get_i16(bytes, &p);
+				break;
+
+			case PRM_TYPE_SPOT_LIGHT:
+				prm.ptr = mem_bump(sizeof(SpotLight));
+				prm.spotLight->type = prm_type;
+				prm.spotLight->flag = prm_flag;
+				prm.spotLight->position.x = get_i32(bytes, &p);
+				prm.spotLight->position.y = get_i32(bytes, &p);
+				prm.spotLight->position.z = get_i32(bytes, &p);
+				p += 4; // padding
+				prm.spotLight->direction.x = get_i16(bytes, &p);
+				prm.spotLight->direction.y = get_i16(bytes, &p);
+				prm.spotLight->direction.z = get_i16(bytes, &p);
+				p += 2; // padding
+				prm.spotLight->color = argb_from_u32(get_u32(bytes, &p));
+				prm.spotLight->startFalloff = get_i16(bytes, &p);
+				prm.spotLight->endFalloff = get_i16(bytes, &p);
+				prm.spotLight->coneAngle = get_i16(bytes, &p);
+				prm.spotLight->spreadAngle = get_i16(bytes, &p);
+				break;
+
+			case PRM_TYPE_INFINITE_LIGHT:
+				prm.ptr = mem_bump(sizeof(InfiniteLight));
+				prm.infiniteLight->type = prm_type;
+				prm.infiniteLight->flag = prm_flag;
+				prm.infiniteLight->direction.x = get_i16(bytes, &p);
+				prm.infiniteLight->direction.y = get_i16(bytes, &p);
+				prm.infiniteLight->direction.z = get_i16(bytes, &p);
+				p += 2; // padding
+				prm.infiniteLight->color = argb_from_u32(get_u32(bytes, &p));
+				break; */
+			default:
+				die("bad primitive type %x \n", prm_type);
+			} // switch
 		} // each prim
 	} // each object
 

--- a/src/wipeout/object.c
+++ b/src/wipeout/object.c
@@ -27,12 +27,7 @@ Object *objects_load(char *name, texture_list_t tl) {
 	Object *prevObject = NULL;
 	uint32_t p = 0;
 
-	int total_double = 0;
-	int total_single = 0;
-
 	while (p < length) {
-		int count_singleface = 0;
-		int count_doubleface = 0;
 		Object *object = mem_bump(sizeof(Object));
 		if (prevObject) {
 			prevObject->next = object;
@@ -107,14 +102,6 @@ Object *objects_load(char *name, texture_list_t tl) {
 			Prm prm;
 			int16_t prm_type = get_i16(bytes, &p);
 			int16_t prm_flag = get_i16(bytes, &p);
-
-			if (flags_is(prm_flag, PRM_SINGLE_SIDED)) {
-				count_singleface++;
-				total_single++;
-			} else {
-				count_doubleface++;
-				total_double++;
-			}
 
 			switch (prm_type) {
 			case PRM_TYPE_F3:
@@ -457,107 +444,9 @@ Object *objects_load(char *name, texture_list_t tl) {
 				die("bad primitive type %x \n", prm_type);
 			} // switch
 
-			prm.f3->type = prm_type;
-			prm.f3->flag = prm_flag;
+			prm.primitive->type = prm_type;
+			prm.primitive->flag = prm_flag;
 		} // each prim
-
-		object->primitives_singleface_len = count_singleface;
-		object->primitives_doubleface_len = count_doubleface;
-		object->primitives_singleface = (Primitive **)mem_bump(sizeof(Primitive *) * count_singleface);
-		object->primitives_doubleface = (Primitive **)mem_bump(sizeof(Primitive *) * count_doubleface);
-		Prm poly = {.primitive = object->primitives};
-		int primitives_len = object->primitives_len;
-		int index_singleface = 0;
-		int index_doubleface = 0;
-		for (int i = 0; i < primitives_len; i++) {
-			switch (poly.primitive->type) {
-			case PRM_TYPE_GT3:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.gt3 += 1;
-				break;
-
-			case PRM_TYPE_GT4:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.gt4 += 1;
-				break;
-
-			case PRM_TYPE_FT3:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.ft3 += 1;
-				break;
-
-			case PRM_TYPE_FT4:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.ft4 += 1;
-				break;
-
-			case PRM_TYPE_G3:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.g3 += 1;
-				break;
-
-			case PRM_TYPE_G4:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.g4 += 1;
-				break;
-
-			case PRM_TYPE_F3:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.f3 += 1;
-				break;
-
-			case PRM_TYPE_F4:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.f4 += 1;
-				break;
-
-			case PRM_TYPE_TSPR:
-			case PRM_TYPE_BSPR:
-				if (flags_is(poly.primitive->flag, PRM_SINGLE_SIDED)) {
-					object->primitives_singleface[index_singleface++] = poly.primitive;
-				} else {
-					object->primitives_doubleface[index_doubleface++] = poly.primitive;
-				}
-				poly.spr += 1;
-				break;
-
-			default:
-				break;
-
-			}	
-		}
 	} // each object
 
 	mem_temp_free(bytes);
@@ -568,15 +457,12 @@ Object *objects_load(char *name, texture_list_t tl) {
 void object_draw(Object *object, mat4_t *mat) {
 	vec3_t *vertex = object->vertices;
 
-	int singleface_len = object->primitives_singleface_len;
-	int doubleface_len = object->primitives_doubleface_len;
+	Prm poly = {.primitive = object->primitives};
+	int primitives_len = object->primitives_len;
 
 	render_set_model_mat(mat);
 
-	render_set_cull_backface(true);
-	Primitive **ppoly = object->primitives_singleface;
-	for (int i = 0; i < singleface_len; i++) {
-		Prm poly = {.primitive = ppoly[i]};
+	for (int i = 0; i < primitives_len; i++) {
 		int coord0;
 		int coord1;
 		int coord2;
@@ -607,6 +493,28 @@ void object_draw(Object *object, mat4_t *mat) {
 					},
 				}
 			}, poly.gt3->texture);
+
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt3->u0, poly.gt3->v0},
+							.color = poly.gt3->color[0]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt3->u1, poly.gt3->v1},
+							.color = poly.gt3->color[1]
+						},
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt3->u2, poly.gt3->v2},
+							.color = poly.gt3->color[2]
+						},
+					}
+				}, poly.gt3->texture);
+			}
 
 			poly.gt3 += 1;
 			break;
@@ -655,6 +563,47 @@ void object_draw(Object *object, mat4_t *mat) {
 					},
 				}
 			}, poly.gt4->texture);
+
+			if (flags_not(poly.primitive->flag, PRM_SINGLE_SIDED)) {
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord0],
+							.uv = {poly.gt4->u0, poly.gt4->v0},
+							.color = poly.gt4->color[0]
+						},
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+					}
+				}, poly.gt4->texture);
+				render_push_tris((tris_t) {
+					.vertices = {
+						{
+							.pos = vertex[coord1],
+							.uv = {poly.gt4->u1, poly.gt4->v1},
+							.color = poly.gt4->color[1]
+						},
+						{
+							.pos = vertex[coord3],
+							.uv = {poly.gt4->u3, poly.gt4->v3},
+							.color = poly.gt4->color[3]
+						},
+						{
+							.pos = vertex[coord2],
+							.uv = {poly.gt4->u2, poly.gt4->v2},
+							.color = poly.gt4->color[2]
+						},
+					}
+				}, poly.gt4->texture);
+			}
 
 			poly.gt4 += 1;
 			break;
@@ -881,7 +830,8 @@ void object_draw(Object *object, mat4_t *mat) {
 				),
 				vec2i(poly.spr->width, poly.spr->height),
 				poly.spr->color,
-				poly.spr->texture
+				poly.spr->texture,
+				poly.primitive->flag
 			);
 
 			poly.spr += 1;
@@ -891,326 +841,6 @@ void object_draw(Object *object, mat4_t *mat) {
 			break;
 
 		}
-	}
-
-	render_set_cull_backface(false);
-	ppoly = object->primitives_doubleface;
-	for (int i = 0; i < doubleface_len; i++) {
-		Prm poly = {.primitive = ppoly[i]};
-		int coord0;
-		int coord1;
-		int coord2;
-		int coord3;
-
-		switch (poly.primitive->type) {
-		case PRM_TYPE_GT3:
-			coord0 = poly.gt3->coords[0];
-			coord1 = poly.gt3->coords[1];
-			coord2 = poly.gt3->coords[2];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt3->u2, poly.gt3->v2},
-						.color = poly.gt3->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt3->u1, poly.gt3->v1},
-						.color = poly.gt3->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.gt3->u0, poly.gt3->v0},
-						.color = poly.gt3->color[0]
-					},
-				}
-			}, poly.gt3->texture);
-
-			poly.gt3 += 1;
-			break;
-
-		case PRM_TYPE_GT4:
-			coord0 = poly.gt4->coords[0];
-			coord1 = poly.gt4->coords[1];
-			coord2 = poly.gt4->coords[2];
-			coord3 = poly.gt4->coords[3];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt4->u2, poly.gt4->v2},
-						.color = poly.gt4->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt4->u1, poly.gt4->v1},
-						.color = poly.gt4->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.gt4->u0, poly.gt4->v0},
-						.color = poly.gt4->color[0]
-					},
-				}
-			}, poly.gt4->texture);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.gt4->u2, poly.gt4->v2},
-						.color = poly.gt4->color[2]
-					},
-					{
-						.pos = vertex[coord3],
-						.uv = {poly.gt4->u3, poly.gt4->v3},
-						.color = poly.gt4->color[3]
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.gt4->u1, poly.gt4->v1},
-						.color = poly.gt4->color[1]
-					},
-				}
-			}, poly.gt4->texture);
-
-			poly.gt4 += 1;
-			break;
-
-		case PRM_TYPE_FT3:
-			coord0 = poly.ft3->coords[0];
-			coord1 = poly.ft3->coords[1];
-			coord2 = poly.ft3->coords[2];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft3->u2, poly.ft3->v2},
-						.color = poly.ft3->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft3->u1, poly.ft3->v1},
-						.color = poly.ft3->color
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.ft3->u0, poly.ft3->v0},
-						.color = poly.ft3->color
-					},
-				}
-			}, poly.ft3->texture);
-
-			poly.ft3 += 1;
-			break;
-
-		case PRM_TYPE_FT4:
-			coord0 = poly.ft4->coords[0];
-			coord1 = poly.ft4->coords[1];
-			coord2 = poly.ft4->coords[2];
-			coord3 = poly.ft4->coords[3];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft4->u2, poly.ft4->v2},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft4->u1, poly.ft4->v1},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord0],
-						.uv = {poly.ft4->u0, poly.ft4->v0},
-						.color = poly.ft4->color
-					},
-				}
-			}, poly.ft4->texture);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.uv = {poly.ft4->u2, poly.ft4->v2},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord3],
-						.uv = {poly.ft4->u3, poly.ft4->v3},
-						.color = poly.ft4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.uv = {poly.ft4->u1, poly.ft4->v1},
-						.color = poly.ft4->color
-					},
-				}
-			}, poly.ft4->texture);
-
-			poly.ft4 += 1;
-			break;
-
-		case PRM_TYPE_G3:
-			coord0 = poly.g3->coords[0];
-			coord1 = poly.g3->coords[1];
-			coord2 = poly.g3->coords[2];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g3->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g3->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.g3->color[0]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
-			poly.g3 += 1;
-			break;
-
-		case PRM_TYPE_G4:
-			coord0 = poly.g4->coords[0];
-			coord1 = poly.g4->coords[1];
-			coord2 = poly.g4->coords[2];
-			coord3 = poly.g4->coords[3];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g4->color[2]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g4->color[1]
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.g4->color[0]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.g4->color[2]
-					},
-					{
-						.pos = vertex[coord3],
-						.color = poly.g4->color[3]
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.g4->color[1]
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
-			poly.g4 += 1;
-			break;
-
-		case PRM_TYPE_F3:
-			coord0 = poly.f3->coords[0];
-			coord1 = poly.f3->coords[1];
-			coord2 = poly.f3->coords[2];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f3->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f3->color
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.f3->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
-			poly.f3 += 1;
-			break;
-
-		case PRM_TYPE_F4:
-			coord0 = poly.f4->coords[0];
-			coord1 = poly.f4->coords[1];
-			coord2 = poly.f4->coords[2];
-			coord3 = poly.f4->coords[3];
-
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord0],
-						.color = poly.f4->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-			render_push_tris((tris_t) {
-				.vertices = {
-					{
-						.pos = vertex[coord2],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord3],
-						.color = poly.f4->color
-					},
-					{
-						.pos = vertex[coord1],
-						.color = poly.f4->color
-					},
-				}
-			}, RENDER_NO_TEXTURE);
-
-			poly.f4 += 1;
-			break;
-
-		case PRM_TYPE_TSPR:
-		case PRM_TYPE_BSPR:
-			coord0 = poly.spr->coord;
-
-			render_push_sprite(
-				vec3(
-					vertex[coord0].x,
-					vertex[coord0].y + ((poly.primitive->type == PRM_TYPE_TSPR ? poly.spr->height : -poly.spr->height) >> 1),
-					vertex[coord0].z
-				),
-				vec2i(poly.spr->width, poly.spr->height),
-				poly.spr->color,
-				poly.spr->texture
-			);
-
-			poly.spr += 1;
-			break;
-
-		default:
-			break;
-
-		}		
 	}
 }
 

--- a/src/wipeout/object.h
+++ b/src/wipeout/object.h
@@ -341,11 +341,6 @@ typedef struct Object {
 	int16_t primitives_len; // Number of Primitives
 	Primitive *primitives; // Pointer to Z Sort Primitives
 
-	int16_t primitives_singleface_len; // Number of Primitives
-	Primitive **primitives_singleface;
-	int16_t primitives_doubleface_len; // Number of Primitives
-	Primitive **primitives_doubleface;
-
 	vec3_t origin;
 	int32_t extent; // Flags for object characteristics
 	int16_t flags; // Next object in list

--- a/src/wipeout/object.h
+++ b/src/wipeout/object.h
@@ -10,6 +10,7 @@
 
 typedef struct Primitive {
 	int16_t type; // Type of Primitive
+	int16_t flag;
 } Primitive;
 
 

--- a/src/wipeout/object.h
+++ b/src/wipeout/object.h
@@ -341,6 +341,11 @@ typedef struct Object {
 	int16_t primitives_len; // Number of Primitives
 	Primitive *primitives; // Pointer to Z Sort Primitives
 
+	int16_t primitives_singleface_len; // Number of Primitives
+	Primitive **primitives_singleface;
+	int16_t primitives_doubleface_len; // Number of Primitives
+	Primitive **primitives_doubleface;
+
 	vec3_t origin;
 	int32_t extent; // Flags for object characteristics
 	int16_t flags; // Next object in list

--- a/src/wipeout/particle.c
+++ b/src/wipeout/particle.c
@@ -4,6 +4,7 @@
 #include "../render.h"
 
 #include "particle.h"
+#include "object.h"
 #include "image.h"
 
 static particle_t *particles;
@@ -45,7 +46,7 @@ void particles_draw(void) {
 
 	for (int i = 0; i < particles_active; i++) {
 		particle_t *p = &particles[i];
-		render_push_sprite(p->position, p->size, p->color, p->texture);
+		render_push_sprite(p->position, p->size, p->color, p->texture, PRM_SINGLE_SIDED);
 	}
 
 	render_set_depth_offset(0.0);

--- a/src/wipeout/race.c
+++ b/src/wipeout/race.c
@@ -106,10 +106,8 @@ void race_update(void) {
 	render_set_view(g.camera.position, g.camera.angle);
 	render_set_screen_position(g.camera.shake);
 
-	render_set_cull_backface(false);
 	scene_draw(&g.camera);
 	track_draw(&g.camera);
-	render_set_cull_backface(true);
 
 	ships_draw();
 	droid_draw(&g.droid);

--- a/src/wipeout/race.c
+++ b/src/wipeout/race.c
@@ -107,7 +107,9 @@ void race_update(void) {
 	render_set_screen_position(g.camera.shake);
 
 	scene_draw(&g.camera);
+	render_set_cull_backface(false);
 	track_draw(&g.camera);
+	render_set_cull_backface(true);
 
 	ships_draw();
 	droid_draw(&g.droid);


### PR DESCRIPTION
With a small modification to `objects_load` (a two-pass load that skips `PRM_SHIP_ENGINE` primitives during the first pass), all of the exhaust primitives can be appended to the end of the primitive list for ships.

This fixes the track image bleed and does not require messing with depth write / depth test.