### PR TITLE
Fix Windows MSYS2 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build/
 
 /wipegame
+/wipegame.exe
 /save.dat
 .DS_STORE
 gamecontrollerdb.txt

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ else ifeq ($(shell uname -o), Msys)
 
 	C_FLAGS := $(C_FLAGS) -DSDL_MAIN_HANDLED -D__MSYS__
 	L_FLAGS_SDL := $(shell sdl2-config --libs)
-	L_FLAGS_SOKOL = --pthread -ldl -lasound
+	L_FLAGS_SOKOL = --pthread -lgdi32 -lole32
 
 
 # Windows NON-MSYS ---------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ else ifeq ($(shell uname -o), Msys)
 	endif
 
 	C_FLAGS := $(C_FLAGS) -DSDL_MAIN_HANDLED -D__MSYS__
-	L_FLAGS_SDL = -lSDL2 -lSDL2main
+	L_FLAGS_SDL := $(shell sdl2-config --libs)
 	L_FLAGS_SOKOL = --pthread -ldl -lasound
 
 


### PR DESCRIPTION
Both the SDL2 and Sokol builds of the game are broken with the current linker flags.
- Using ``sdl2-config --libs`` will additionally pass ``-lming32 -mwindows`` which fixes the undefined reference to WinMain preventing the target executable from linking. Since we're already using ``sdl2-config --cflags``, this seems like the most appropriate solution.
- There is no libdl or libasound on Windows. The Sokol build requires libgdi32 and libole32 to link. Alternatively, passing ``-mwindows -lole32`` also works.
- The target executable will be named ``wipegame.exe`` on Windows, not ``wipegame``, so I've added the former to the .gitignore since we don't want that committed.