### PR TITLE
Ship bounces when shot by a missile/rocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ Some things from the original game are not yet implemented in this rewrite. This
 
 - less punishing physics for ship vs. ship collisions
 - less punishing physics for sideways ship vs. track collisions (i.e. wall grinding like in newer wipEouts)
-- somehow resolve the issue of inevitably running into an enemy that you just shot
 - add additional external view that behaves more like in modern racing games
 - dynamic lighting on ships
 - the scene geometry could use some touch-ups to make an infinite draw distance option less awkward

--- a/src/wipeout/weapon.c
+++ b/src/wipeout/weapon.c
@@ -442,6 +442,8 @@ void weapon_update_missile(weapon_t *self) {
 				ship->angular_velocity.z += 10 * M_PI;
 				ship->turn_rate_from_hit = rand_float(-M_PI, M_PI);
 			}
+			track_face_t *face = track_section_get_base_face(ship->section);
+			ship->velocity = vec3_add(ship->velocity, vec3_mulf(face->normal, 10000));
 		}
 	}
 }
@@ -490,6 +492,8 @@ void weapon_update_rocket(weapon_t *self) {
 				ship->angular_velocity.z += 10 * M_PI;
 				ship->turn_rate_from_hit = rand_float(-M_PI, M_PI);
 			}
+			track_face_t *face = track_section_get_base_face(ship->section);
+			ship->velocity = vec3_add(ship->velocity, vec3_mulf(face->normal, 10000));
 		}
 	}
 }


### PR DESCRIPTION
Ship bounces along the base face normal when shot by a rocket/missile without a shield.
If the player shoots a ship at close range, they will fly under the hit opponent.
If the player shoots a ship from far away, they will have time to take avoiding action.
This mechanic was present in 2097.

I don't know why I didn't open a PR for it back then.
Open to suggestions. My math is still just tinkering without much knowledge.