### PR TITLE
Added debug frame stats

### DIFF
--- a/src/render.h
+++ b/src/render.h
@@ -20,6 +20,11 @@ typedef enum {
 	NUM_RENDER_POST_EFFCTS,
 } render_post_effect_t;
 
+typedef struct {
+	uint32_t num_tris;
+	uint32_t num_draw_calls;
+} render_stats_t;
+
 #define RENDER_USE_MIPMAPS 1
 
 #define RENDER_FADEOUT_NEAR 48000.0
@@ -37,6 +42,8 @@ vec2i_t render_size(void);
 
 void render_frame_prepare(void);
 void render_frame_end(void);
+// render_stats_t owned by the renderer
+const render_stats_t* render_frame_get_stats(void);
 
 void render_set_view(vec3_t pos, vec3_t angles);
 void render_set_view_2d(void);

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -378,6 +378,11 @@ prg_game_t *prg_game;
 prg_post_t *prg_post;
 prg_post_t *prg_post_effects[NUM_RENDER_POST_EFFCTS] = {};
 
+// Intra-frame counts
+static render_stats_t running_stats = {0};
+// Previous frame's total stats (copy of running_stats in render_frame_end())
+static render_stats_t end_stats = {0};
+
 
 static void render_flush(void);
 
@@ -585,6 +590,9 @@ void render_frame_prepare(void) {
 	glClearColor(0, 0, 0, 1);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	glEnable(GL_DEPTH_TEST); 
+
+	running_stats.num_tris = 0;
+	running_stats.num_draw_calls = 0;
 }
 
 void render_frame_end(void) {
@@ -619,6 +627,13 @@ void render_frame_end(void) {
 	};
 
 	render_flush();
+	
+	// Only here do we have the complete stats
+	memcpy(&end_stats, &running_stats, sizeof(render_stats_t));
+}
+
+const render_stats_t* render_frame_get_stats(void) {
+	return &end_stats;
 }
 
 void render_flush(void) {
@@ -630,6 +645,9 @@ void render_flush(void) {
 		glGenerateMipmap(GL_TEXTURE_2D);
 		texture_mipmap_is_dirty = false;
 	}
+
+	running_stats.num_tris += tris_len;
+	running_stats.num_draw_calls++;
 
 	glBindBuffer(GL_ARRAY_BUFFER, vbo);
 	glBufferData(GL_ARRAY_BUFFER, sizeof(tris_t) * tris_len, tris_buffer, GL_DYNAMIC_DRAW);

--- a/src/render_null.c
+++ b/src/render_null.c
@@ -1,5 +1,7 @@
 #include "render.h"
 
+static render_stats_t dummy_stats = {0};
+
 uint16_t RENDER_NO_TEXTURE;
 
 void render_init(vec2i_t screen_size) {
@@ -22,6 +24,9 @@ vec2i_t render_size(void) {
 
 void render_frame_prepare(void) {}
 void render_frame_end(void) {}
+const render_stats_t* render_frame_get_stats(void) {
+	return &dummy_stats;
+}
 
 void render_set_view(vec3_t pos, vec3_t angles) {
 	(void) pos; (void) angles;

--- a/src/render_software.c
+++ b/src/render_software.c
@@ -55,6 +55,11 @@ uint16_t RENDER_NO_TEXTURE;
 int32_t tris_buffer_len = 0;
 clip_tris_t tris_buffer[TRIS_BUFFER_SIZE];
 
+// Intra-frame counts
+static render_stats_t running_stats = {0};
+// Previous frame's total stats (copy of running_stats in render_frame_end())
+static render_stats_t end_stats = {0};
+
 
 void render_init(vec2i_t screen_size) {
 	render_set_screen_size(screen_size);
@@ -121,10 +126,18 @@ void render_frame_prepare(void) {
 	for (uint32_t i = 0; i < depth_buffer_len; i++) {
 		depth_buffer[i] = 1.0f;
 	}
+
+	running_stats.num_tris = 0;
+	running_stats.num_draw_calls = 0;
 }
 
 void render_frame_end(void) {
 	render_flush();
+	memcpy(&end_stats, &running_stats, sizeof(render_stats_t));
+}
+
+const render_stats_t* render_frame_get_stats(void) {
+	return &end_stats;
 }
 
 void render_set_view(vec3_t pos, vec3_t angles) {
@@ -211,6 +224,10 @@ static void render_flush(void) {
 	// rasterization, but it still helps a little to skip it when depth testing.
 
 	qsort(tris_buffer, tris_buffer_len, sizeof(clip_tris_t), sort_sw_tris_by_depth);
+
+	running_stats.num_tris += tris_buffer_len;
+	// Not draw calls but draw buffer sorts
+	running_stats.num_draw_calls++;
 
 	for (int i = 0; i < tris_buffer_len; i++) {
 		draw_tris(tris_buffer[i]);

--- a/src/wipeout/game.c
+++ b/src/wipeout/game.c
@@ -399,7 +399,7 @@ save_t save = {
 	.internal_roll = 0.6,
 	.screen_shake = 0.5,
 	.ui_scale = 0,
-	.show_fps = false,
+	.draw_stats = DRAW_STATS_OFF,
 	.fullscreen = false,
 	.screen_res = 0,
 	.post_effect = 0,
@@ -656,5 +656,7 @@ void game_update(void) {
 	if (g.frame_time > 0) {
 		g.frame_rate = ((double)g.frame_rate * 0.95) + (1.0/g.frame_time) * 0.05;
 	}
+	
+	// The only drawing left here should be the post process
 }
 

--- a/src/wipeout/game.h
+++ b/src/wipeout/game.h
@@ -102,6 +102,13 @@ enum circut {
 	NUM_CIRCUTS
 };
 
+// How detailed are the stats? Just the FPS or draw internals
+typedef enum {
+	DRAW_STATS_OFF,
+	DRAW_STATS_FPS,
+	DRAW_STATS_DEBUG
+} draw_stats_t;
+
 
 // Game definitions
 
@@ -242,7 +249,7 @@ typedef struct {
 	float music_volume;
 	float internal_roll;
 	uint8_t ui_scale;
-	bool show_fps;
+	draw_stats_t draw_stats;
 	bool fullscreen;
 	int screen_res;
 	int post_effect;

--- a/src/wipeout/hud.c
+++ b/src/wipeout/hud.c
@@ -210,10 +210,24 @@ void hud_draw(ship_t *ship) {
 		ui_draw_number(ship->position_rank, ui_scaled_pos(UI_POS_TOP | UI_POS_RIGHT, vec2i(-60, 19)), UI_SIZE_16, UI_COLOR_DEFAULT);
 	}
 
-	// Framerate
-	if (save.show_fps) {
+	// Framerate/draw stats
+	switch (save.draw_stats) {
+	case DRAW_STATS_FPS:
 		ui_draw_text("FPS", ui_scaled(vec2i(16, 78)), UI_SIZE_8, UI_COLOR_ACCENT);
 		ui_draw_number((int)(g.frame_rate), ui_scaled(vec2i(16, 90)), UI_SIZE_8, UI_COLOR_DEFAULT);
+		break;
+	case DRAW_STATS_DEBUG: {
+		ui_draw_text("TRIS", ui_scaled(vec2i(16, 78)), UI_SIZE_8, UI_COLOR_ACCENT);
+		ui_draw_text("CALLS", ui_scaled(vec2i(80, 78)), UI_SIZE_8, UI_COLOR_ACCENT);
+		ui_draw_text("MS", ui_scaled(vec2i(144, 78)), UI_SIZE_8, UI_COLOR_ACCENT);
+		const render_stats_t *stats = render_frame_get_stats();
+		ui_draw_number((int)(stats->num_tris), ui_scaled(vec2i(16, 90)), UI_SIZE_8, UI_COLOR_DEFAULT);
+		ui_draw_number((int)(stats->num_draw_calls), ui_scaled(vec2i(80, 90)), UI_SIZE_8, UI_COLOR_DEFAULT);
+		ui_draw_number((int)(g.frame_time * 1000), ui_scaled(vec2i(144, 90)), UI_SIZE_8, UI_COLOR_DEFAULT);
+		break;
+	}
+	default:
+		break;
 	}
 
 	// Lap Record

--- a/src/wipeout/main_menu.c
+++ b/src/wipeout/main_menu.c
@@ -281,8 +281,8 @@ static void toggle_internal_roll(menu_t *menu, int data) {
 	save.is_dirty = true;
 }
 
-static void toggle_show_fps(menu_t *menu, int data) {
-	save.show_fps = data;
+static void toggle_draw_stats(menu_t *menu, int data) {
+	save.draw_stats = data;
 	save.is_dirty = true;
 }
 
@@ -311,6 +311,7 @@ static void toggle_screen_shake(menu_t *menu, int data) {
 static const char *opts_off_on[] = {"OFF", "ON"};
 static const char *opts_roll[] = {"0", "10", "20", "30", "40", "50", "60", "70", "80", "90", "100"};
 static const char *opts_ui_sizes[] = {"AUTO", "1X", "2X", "3X", "4X"};
+static const char *opts_draw_stats[] = {"OFF", "FPS", "DEBUG"};
 static const char *opts_res[] = {"NATIVE", "240P", "480P"};
 static const char *opts_post[] = {"NONE", "CRT EFFECT"};
 static const char *opts_screen_shake[] = {"DISABLED", "REDUCED", "FULL"};
@@ -330,7 +331,7 @@ static void page_options_video_init(menu_t *menu) {
 	menu_page_add_toggle(page, save.internal_roll * 10, "INTERNAL VIEW ROLL", opts_roll, len(opts_roll), toggle_internal_roll);
 	menu_page_add_toggle(page, save.screen_shake * 2, "SCREEN SHAKE", opts_screen_shake, len(opts_screen_shake), toggle_screen_shake);
 	menu_page_add_toggle(page, save.ui_scale, "UI SCALE", opts_ui_sizes, len(opts_ui_sizes), toggle_ui_scale);
-	menu_page_add_toggle(page, save.show_fps, "SHOW FPS", opts_off_on, len(opts_off_on), toggle_show_fps);
+	menu_page_add_toggle(page, save.draw_stats, "DRAW STATS", opts_draw_stats, len(opts_draw_stats), toggle_draw_stats);
 	menu_page_add_toggle(page, save.screen_res, "SCREEN RESOLUTION", opts_res, len(opts_res), toggle_res);
 	menu_page_add_toggle(page, save.post_effect, "POST PROCESSING", opts_post, len(opts_post), toggle_post);
 }


### PR DESCRIPTION
The video menu FPS option was changed to toggle between FPS and frame stats, then in-game shows triangles, draw calls and millis per frame:

<img width="472" height="260" alt="stats" src="https://github.com/user-attachments/assets/3b6cf471-42e1-4426-ac84-4cc3c0b4221d" />

Tested with the GL and software renderers (with a dummy implementation for the null renderer).