### PR TITLE
Fix recovery loop

### DIFF
--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -391,24 +391,17 @@ void ship_player_update_race(ship_t *self) {
 		else {
 			self->angular_acceleration.x += NTSC_ACCELERATION(ANGLE_NORM_TO_RADIAN(FIXED_TO_FLOAT(-50.0/16.0)));
 		}
-
-		//	Have we somehow flown off of the track into the scenery?
-		float distance = ship_player_find_distance_from_track(self);
-		if (distance > 10000 && vec3_len(self->velocity) == 0) {
-			section_t *landing = self->section->prev;
-			ship_player_begin_rescue_to_section(self, landing);
-		}
 	}
 
 	// Flying
 	else {
-		// Detect the need for a rescue droid
+		//	Detect the need for a rescue droid
 		float distance = ship_player_find_distance_from_track(self);
 
-		// Do we need to be rescued?
-		if (distance > 8000) {
+		//	We've fallen off of a jump, rescue to the other side
+		if (distance > 8000 && flags_is(self->section->flags, SECTION_JUMP)) {
 			section_t *landing = self->section->prev;
-
+			
 			while(flags_not(landing->flags, SECTION_JUMP)) {
 				landing = landing->next;
 			}
@@ -416,19 +409,25 @@ void ship_player_update_race(ship_t *self) {
 
 			ship_player_begin_rescue_to_section(self, landing);
 		}
-
-
-		float brake = (self->brake_left + self->brake_right);
-		float resistance = (self->resistance * (SHIP_MAX_RESISTANCE - (brake * 0.125))) * 0.0078125;
-
-		vec3_t force = vec3(0, SHIP_FLYING_GRAVITY, 0);
-		force = vec3_add(force, self->thrust);
-
-		self->acceleration = vec3_divf(vec3_sub(forward_velocity, self->velocity), SHIP_MIN_RESISTANCE + brake * 4);
-		self->acceleration = vec3_add(self->acceleration, vec3_divf(force, self->mass));
-		self->acceleration = vec3_sub(self->acceleration, vec3_divf(self->velocity, resistance));
-
-		self->angular_acceleration.x += NTSC_ACCELERATION(ANGLE_NORM_TO_RADIAN(FIXED_TO_FLOAT(-50.0/16.0)));
+		//	We've flown off the track into the scenery, rescue to last on-track position
+		else if (distance > 10000) {
+			section_t *landing = self->section->prev;
+			ship_player_begin_rescue_to_section(self, landing);
+		}
+		//	Everything is normal, manouver through the air
+		else {
+			float brake = (self->brake_left + self->brake_right);
+			float resistance = (self->resistance * (SHIP_MAX_RESISTANCE - (brake * 0.125))) * 0.0078125;
+	
+			vec3_t force = vec3(0, SHIP_FLYING_GRAVITY, 0);
+			force = vec3_add(force, self->thrust);
+	
+			self->acceleration = vec3_divf(vec3_sub(forward_velocity, self->velocity), SHIP_MIN_RESISTANCE + brake * 4);
+			self->acceleration = vec3_add(self->acceleration, vec3_divf(force, self->mass));
+			self->acceleration = vec3_sub(self->acceleration, vec3_divf(self->velocity, resistance));
+	
+			self->angular_acceleration.x += NTSC_ACCELERATION(ANGLE_NORM_TO_RADIAN(FIXED_TO_FLOAT(-50.0/16.0)));
+		}
 	}
 
 	// Position

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -488,8 +488,8 @@ void ship_player_update_rescue(ship_t *self) {
 
 
 	// Are we done being rescued?
-	float distance = vec3_len(vec3_sub(self->position, self->temp_target));
-	if (flags_is(self->flags, SHIP_IN_TOW) && distance < 800) {
+	float distance = ship_player_find_distance_from_track(self);
+	if (flags_is(self->flags, SHIP_IN_TOW) && distance < 300) {
 		self->update_func = ship_player_update_race;
 		self->update_timer = 0;
 		flags_rm(self->flags, SHIP_IN_RESCUE);
@@ -512,7 +512,7 @@ void ship_player_begin_rescue_to_section(ship_t *self, section_t *section)
 	flags_add(self->flags, SHIP_IN_RESCUE | SHIP_FLYING);
 
 	self->section = section;
-	self->temp_target = vec3_mulf(vec3_add(section->center, section->next->center), 0.5);
+	self->temp_target = vec3_mulf(vec3_add(section->center, section->next->center), 0.55);
 	self->temp_target.y -= 2000;
 	self->velocity = vec3(0, 0, 0);
 }

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -423,7 +423,7 @@ void ship_player_update_race(ship_t *self) {
 			}
 
 			self->section = landing;
-			self->temp_target = vec3_mulf(vec3_add(landing->center, landing->next->center), 0.5);
+			self->temp_target = vec3_mulf(vec3_add(landing->center, landing->next->center), 0.55);
 			self->temp_target.y -= 2000;
 			self->velocity = vec3(0, 0, 0);
 		}

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -418,9 +418,10 @@ void ship_player_update_race(ship_t *self) {
 			for (int i = 0; i < 3; i++) {
 				landing = landing->prev;
 			}
-			for (int i = 0; i < 10 && flags_not(landing->flags, SECTION_JUMP); i++) {
+			while(flags_not(landing->flags, SECTION_JUMP)) {
 				landing = landing->next;
 			}
+
 			self->section = landing;
 			self->temp_target = vec3_mulf(vec3_add(landing->center, landing->next->center), 0.5);
 			self->temp_target.y -= 2000;

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -415,9 +415,7 @@ void ship_player_update_race(ship_t *self) {
 			flags_add(self->flags, SHIP_IN_RESCUE | SHIP_FLYING);
 
 			section_t *landing = self->section->prev;
-			for (int i = 0; i < 3; i++) {
-				landing = landing->prev;
-			}
+
 			while(flags_not(landing->flags, SECTION_JUMP)) {
 				landing = landing->next;
 			}

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -419,9 +419,10 @@ void ship_player_update_race(ship_t *self) {
 			while(flags_not(landing->flags, SECTION_JUMP)) {
 				landing = landing->next;
 			}
+			landing = landing->next;
 
 			self->section = landing;
-			self->temp_target = vec3_mulf(vec3_add(landing->center, landing->next->center), 0.55);
+			self->temp_target = vec3_mulf(vec3_add(landing->center, landing->next->center), 0.52);
 			self->temp_target.y -= 2000;
 			self->velocity = vec3(0, 0, 0);
 		}


### PR DESCRIPTION
Resolves #90, #104 and #128 

## Changes
* Removes the upper-bounds / limit (`10`) from iterative attempts at identifying a viable recovery position
* Slightly increases the recovery distance from the edge of the jump

## Steps to reproduce the issue:
The easiest method I've found for reproducing this problem (without changing any of the game code) is on Terramax using Feisar.
1. As you approach the tracks second jump, reduce throttle so that speed is about 1/2 to 2/3 across the bar
2. Nosedown the ship as much as possible, aim to have the top of the ship in parallel with the wall of the jumps landing-side

## Side effects
* ~~It's still possible to land in problematic recovery positions, but the ship will find its' way back onto the track after one or two attempts. The issue still exists in some form but no longer poses an effective "end" to the race.~~
* Whether this is still true is unknown ^ more testing is needed but it no longer seems to pose an issue