### PR TITLE
Wipeout 64 circuit support

### DIFF
--- a/src/wipeout/image.c
+++ b/src/wipeout/image.c
@@ -51,6 +51,9 @@ image_t *image_load_from_bytes(uint8_t *bytes, bool transparent) {
 	uint32_t type = get_i32_le(bytes, &p);
 	rgba_t palette[256];
 
+	// Wipeout 64 compatibility
+	type &= 0xF;
+
 	if (
 		type == TIM_TYPE_PALETTED_4_BPP ||
 		type == TIM_TYPE_PALETTED_8_BPP

--- a/src/wipeout/scene.c
+++ b/src/wipeout/scene.c
@@ -50,11 +50,35 @@ void scene_move_oil_pump(Object *obj);
 void scene_update_aurora_borealis(void);
 
 void scene_load(const char *base_path, float sky_y_offset) {
-	texture_list_t scene_textures = image_get_compressed_textures(get_path(base_path, "scene.cmp"));
-	scene_objects = objects_load(get_path(base_path, "scene.prm"), scene_textures);
+	bool multiplayer = false;
+	if (str_starts_with(base_path, "wipeout64/")) {
+		// Wipeout 64's skies appear to be rendered in a way reminiscent of
+		// Mario 64, rather than using an actual model. There is a 'sky.prm'
+		// model present in the Wipeout files, but it is a red herring - it's
+		// apparently corrupt and inaccurate to the final game's rendering.
+		// As such, we stub out the skybox. TODO: make a custom skybox model,
+		// or reimplement Wipeout 64's sky rendering.
+		sky_object = &(Object){0};
+
+		// Wipeout 64 splits its scenery into "common" scenery and
+		// "multiplayer" / "singleplayer" specific scenery.
+		// We simply glue the latter to the end of the former.
+		texture_list_t scene_textures = image_get_compressed_textures(get_path(base_path, "sceneCom.cmp"));
+		scene_objects = objects_load(get_path(base_path, "sceneCom.prm"), scene_textures);
+
+		Object *obj = scene_objects;
+		while (obj->next) obj = obj->next;
+
+		texture_list_t scene_extra_textures = image_get_compressed_textures(get_path(base_path, multiplayer ? "sceneMul.cmp" : "sceneSin.cmp"));
+		obj->next = objects_load(get_path(base_path, multiplayer ? "sceneMul.prm" : "sceneSin.prm"), scene_extra_textures);
+	} else {
+		texture_list_t sky_textures = image_get_compressed_textures(get_path(base_path, "sky.cmp"));
+		sky_object = objects_load(get_path(base_path, "sky.prm"), sky_textures);
+
+		texture_list_t scene_textures = image_get_compressed_textures(get_path(base_path, "scene.cmp"));
+		scene_objects = objects_load(get_path(base_path, "scene.prm"), scene_textures);
+	}
 	
-	texture_list_t sky_textures = image_get_compressed_textures(get_path(base_path, "sky.cmp"));
-	sky_object = objects_load(get_path(base_path, "sky.prm") , sky_textures);
 	sky_offset = vec3(0, sky_y_offset, 0);
 
 	// Collect all objects that need to be updated each frame

--- a/src/wipeout/track.c
+++ b/src/wipeout/track.c
@@ -13,19 +13,24 @@
 void track_load(const char *base_path) {
 	// Load and assemble high res track tiles
 
+	bool wipeout64_mode = str_starts_with(base_path, "wipeout64/");
 	g.track.textures.start = render_textures_len();
 	g.track.textures.len = 0;
 
 	ttf_t *ttf = track_load_tile_format(get_path(base_path, "library.ttf"));
 	cmp_t *cmp = image_load_compressed(get_path(base_path, "library.cmp"));
-
-	image_t *temp_tile = image_alloc(128, 128);
-	for (int i = 0; i < ttf->len; i++) {
-		for (int tx = 0; tx < 4; tx++) {
-			for (int ty = 0; ty < 4; ty++) {
-				uint32_t sub_tile_index = ttf->tiles[i].near[ty * 4 + tx];
-				image_t *sub_tile = image_load_from_bytes(cmp->entries[sub_tile_index], false);
-				image_copy(sub_tile, temp_tile, 0, 0, 32, 32, tx * 32, ty * 32);
+	int temp_tile_size = wipeout64_mode ? 64 : 128;
+	int sub_tile_size  = wipeout64_mode ? 64 : 32;
+	int tiles          = wipeout64_mode ? 1  : 4;
+	
+	image_t *temp_tile = image_alloc(temp_tile_size, temp_tile_size);
+	int len = wipeout64_mode ? cmp->len : ttf->len;
+	for (int i = 0; i < len; i++) {
+		for (int tx = 0; tx < tiles; tx++) {
+			for (int ty = 0; ty < tiles; ty++) {
+				uint32_t sub_tile_index = ttf->tiles[i].near[ty * tiles + tx];
+				image_t *sub_tile = image_load_from_bytes(cmp->entries[wipeout64_mode ? i : sub_tile_index], false);
+				image_copy(sub_tile, temp_tile, 0, 0, sub_tile_size, sub_tile_size, tx * sub_tile_size, ty * sub_tile_size);
 				mem_temp_free(sub_tile);
 			}
 		}
@@ -144,6 +149,11 @@ static const vec2_t track_uv[2][4] = {
 	{{  0, 0}, {128, 0}, {128, 128}, {  0, 128}}
 };
 
+static const vec2_t wipeout64_track_uv[2][4] = {
+	{{64, 0}, {  0, 0}, {  0, 64}, {64, 64}},
+	{{  0, 0}, {64, 0}, {64, 64}, {  0, 64}}
+};
+
 void track_load_faces(char *file_name, vec3_t *vertices) {
 	uint32_t size;
 	uint8_t *bytes = platform_load_asset(file_name, &size);
@@ -168,9 +178,13 @@ void track_load_faces(char *file_name, vec3_t *vertices) {
 		tf->texture = get_i8(bytes, &p);
 		tf->flags = get_i8(bytes, &p);
 
+		const vec2_t *uv;
 		rgba_t color = rgba_from_u32(get_u32(bytes, &p));
-		const vec2_t *uv = track_uv[flags_is(tf->flags, FACE_FLIP_TEXTURE) ? 1 : 0];
-
+		if (str_starts_with(file_name, "wipeout64/")) {
+			uv = wipeout64_track_uv[flags_is(tf->flags, FACE_FLIP_TEXTURE) ? 1 : 0];
+		} else {
+			uv = track_uv[flags_is(tf->flags, FACE_FLIP_TEXTURE) ? 1 : 0];
+		}
 		tf->tris[0] = (tris_t){
 			.vertices = {
 				{.pos = v0, .uv = uv[0], .color = color},


### PR DESCRIPTION
Rudimentary support for loading Wipeout 64 circuits. This patch does not add any Wipeout 64 specific functionality, it just allows loading these circuits in `wipeout-rewrite` without crashes and corrupted graphics. The sky is not implemented.

[A pull request for the viewer](https://github.com/phoboslab/wipeout/pull/30) was of great help for this.