### PR TITLE
Simplify various color-related code

### DIFF
--- a/src/wipeout/droid.c
+++ b/src/wipeout/droid.c
@@ -52,57 +52,32 @@ void droid_draw(droid_t *droid) {
 	int gf = sin(droid->cycle_timer + 0.2) * 127 + 128;
 	int bf = sin(droid->cycle_timer * 0.5 + 0.1) * 127 + 128;
 
-	int r, g, b;
-
 	for (int i = 0; i < 11; i++) {
+		rgba_t color;
+
 		if (i < 2) {
-			r = 40;
-			g = gf;
-			b = 40;
+			color = rgba(40,gf,40,0xFF);
 		}
 		else if (i < 6) {
-			r = bf >> 1;
-			b = bf;
-			g = bf >> 1;
+			color = rgba(bf >> 1, bf, bf >> 1, 0xFF);
 		}
 		else {
-			r = rf;
-			b = 40;
-			g = 40;
+			color = rgba(rf, 40, 40, 0xFF);
 		}
 
 		switch (prm.f3->type) {
 			case PRM_TYPE_GT3:
-				prm.gt3->color[0].r = r;
-				prm.gt3->color[0].g = g;
-				prm.gt3->color[0].b = b;
-
-				prm.gt3->color[1].r = r;
-				prm.gt3->color[1].g = g;
-				prm.gt3->color[1].b = b;
-
-				prm.gt3->color[2].r = r;
-				prm.gt3->color[2].g = g;
-				prm.gt3->color[2].b = b;
+				prm.gt3->color[0] =
+				prm.gt3->color[1] =
+				prm.gt3->color[2] = color;
 				prm.gt3++;
 				break;
 
 			case PRM_TYPE_GT4:
-				prm.gt4->color[0].r = r;
-				prm.gt4->color[0].g = g;
-				prm.gt4->color[0].b = b;
-
-				prm.gt4->color[1].r = r;
-				prm.gt4->color[1].g = g;
-				prm.gt4->color[1].b = b;
-
-				prm.gt4->color[2].r = r;
-				prm.gt4->color[2].g = g;
-				prm.gt4->color[2].b = b;
-
-				prm.gt4->color[3].r = 40;
-				prm.gt4->color[3].g = 40;
-				prm.gt4->color[3].b = 40;
+				prm.gt4->color[0] =
+				prm.gt4->color[1] =
+				prm.gt4->color[2] = color;
+				prm.gt4->color[3] = rgba(40,40,40,0xFF);
 				prm.gt4++;
 				break;
 		}

--- a/src/wipeout/scene.c
+++ b/src/wipeout/scene.c
@@ -173,9 +173,7 @@ void scene_set_start_booms(int light_index) {
 
 		for (int j = 0; j < lights_len; j++) {
 			for (int v = 0; v < 4; v++) {
-				libPoly.gt4->color[v].r = color.r;
-				libPoly.gt4->color[v].g = color.g;
-				libPoly.gt4->color[v].b = color.b;
+				libPoly.gt4->color[v] = color;
 			}
 			libPoly.gt4 += 1;
 		}
@@ -188,9 +186,7 @@ void scene_pulsate_red_light(Object *obj) {
 	Prm libPoly = {.primitive = obj->primitives};
 
 	for (int v = 0; v < 4; v++) {
-		libPoly.gt4->color[v].r = r;
-		libPoly.gt4->color[v].g = 0x00;
-		libPoly.gt4->color[v].b = 0x00;
+		libPoly.gt4->color[v] = rgba(r,0,0,0xFF);
 	}
 }
 
@@ -236,31 +232,27 @@ void scene_init_aurora_borealis(void) {
 	}
 }
 
+rgba_t scene_aurora_color_from_coordinate(int16_t coord, float phase) {
+	return rgba(
+		 (sin(coord * phase) * 64.0) + 190,
+		 (sin(coord * (phase + 0.054)) * 64.0) + 190,
+		 (sin(coord * (phase + 0.039)) * 64.0) + 190,
+		 0xFF
+	);
+}
+
 void scene_update_aurora_borealis(void) {
 	float phase = system_time() / 30.0;
 	for (int i = 0; i < 80; i++) {
 		int16_t *coords = aurora_borealis.coords[i];
-
+		GT4  *primitive = aurora_borealis.primitives[i];
 		if (aurora_borealis.grey_coords[i] != -2) {
-			aurora_borealis.primitives[i]->color[0].r = (sin(coords[0] * phase) * 64.0) + 190;
-			aurora_borealis.primitives[i]->color[0].g = (sin(coords[0] * (phase + 0.054)) * 64.0) + 190;
-			aurora_borealis.primitives[i]->color[0].b = (sin(coords[0] * (phase + 0.039)) * 64.0) + 190;
-		}
-		if (aurora_borealis.grey_coords[i] != -2) {
-			aurora_borealis.primitives[i]->color[1].r = (sin(coords[1] * phase) * 64.0) + 190;
-			aurora_borealis.primitives[i]->color[1].g = (sin(coords[1] * (phase + 0.054)) * 64.0) + 190;
-			aurora_borealis.primitives[i]->color[1].b = (sin(coords[1] * (phase + 0.039)) * 64.0) + 190;
+			primitive->color[0] = scene_aurora_color_from_coordinate(coords[0], phase);
+			primitive->color[1] = scene_aurora_color_from_coordinate(coords[1], phase);
 		}
 		if (aurora_borealis.grey_coords[i] != -1) {
-			aurora_borealis.primitives[i]->color[2].r = (sin(coords[2] * phase) * 64.0) + 190;
-			aurora_borealis.primitives[i]->color[2].g = (sin(coords[2] * (phase + 0.054)) * 64.0) + 190;
-			aurora_borealis.primitives[i]->color[2].b = (sin(coords[2] * (phase + 0.039)) * 64.0) + 190;
-		}
-
-		if (aurora_borealis.grey_coords[i] != -1) {
-			aurora_borealis.primitives[i]->color[3].r = (sin(coords[3] * phase) * 64.0) + 190;
-			aurora_borealis.primitives[i]->color[3].g = (sin(coords[3] * (phase + 0.054)) * 64.0) + 190;
-			aurora_borealis.primitives[i]->color[3].b = (sin(coords[3] * (phase + 0.039)) * 64.0) + 190;
+			primitive->color[2] = scene_aurora_color_from_coordinate(coords[2], phase);
+			primitive->color[3] = scene_aurora_color_from_coordinate(coords[3], phase);
 		}
 	}
 }

--- a/src/wipeout/ship.c
+++ b/src/wipeout/ship.c
@@ -297,10 +297,7 @@ void ship_init_exhaust_plume(ship_t *self) {
 				indices[indices_len++] = prm.ft3->coords[2];
 
 				flags_add(prm.ft3->flag, PRM_TRANSLUCENT);
-				prm.ft3->color.r = 180;
-				prm.ft3->color.g = 97 ;
-				prm.ft3->color.b = 120;
-				prm.ft3->color.a = 140;
+				prm.ft3->color = rgba(180,97,120,140);
 			}
 			prm.ft3 += 1;
 			break;
@@ -334,10 +331,7 @@ void ship_init_exhaust_plume(ship_t *self) {
 
 				flags_add(prm.gt3->flag, PRM_TRANSLUCENT);
 				for (int j = 0; j < 3; j++) {
-					prm.gt3->color[j].r = 180;
-					prm.gt3->color[j].g = 97 ;
-					prm.gt3->color[j].b = 120;
-					prm.gt3->color[j].a = 140;
+					prm.gt3->color[j] = rgba(180,97,120,140);
 				}
 			}
 			prm.gt3 += 1;

--- a/src/wipeout/weapon.c
+++ b/src/wipeout/weapon.c
@@ -354,15 +354,9 @@ void weapon_update_mine_lights(weapon_t *self, int index) {
 	for (int i = 0; i < 8; i++) {
 		switch (prm.primitive->type) {
 		case PRM_TYPE_GT3:
-			prm.gt3->color[0].r = 230;
-			prm.gt3->color[1].r = r;
-			prm.gt3->color[2].r = r;
-			prm.gt3->color[0].g = 0;
-			prm.gt3->color[1].g = 0x40;
-			prm.gt3->color[2].g = 0x40;
-			prm.gt3->color[0].b = 0;
-			prm.gt3->color[1].b = 0;
-			prm.gt3->color[2].b = 0;
+			prm.gt3->color[0] = rgba(230, 0,    0, 0xFF);
+			prm.gt3->color[1] = rgba(r,   0x40, 0, 0xFF);
+			prm.gt3->color[2] = rgba(r,   0x40, 0, 0xFF);
 			prm.gt3 += 1;
 			break;
 		}
@@ -586,20 +580,9 @@ void weapon_update_shield(weapon_t *self) {
 			col1 = sin(color_timer * coords[1]) * 127 + 128;
 			col2 = sin(color_timer * coords[2]) * 127 + 128;
 
-			poly.g3->color[0].r = col0;
-			poly.g3->color[0].g = col0;
-			poly.g3->color[0].b = 255;
-			poly.g3->color[0].a = shield_alpha;
-
-			poly.g3->color[1].r = col1;
-			poly.g3->color[1].g = col1;
-			poly.g3->color[1].b = 255;
-			poly.g3->color[1].a = shield_alpha;
-
-			poly.g3->color[2].r = col2;
-			poly.g3->color[2].g = col2;
-			poly.g3->color[2].b = 255;
-			poly.g3->color[2].a = shield_alpha;
+			poly.g3->color[0] = rgba(col0, col0, 255, shield_alpha);
+			poly.g3->color[1] = rgba(col1, col1, 255, shield_alpha);
+			poly.g3->color[2] = rgba(col2, col2, 255, shield_alpha);
 			poly.g3 += 1;
 			break;
 
@@ -611,25 +594,10 @@ void weapon_update_shield(weapon_t *self) {
 			col2 = sin(color_timer * coords[2]) * 127 + 128;
 			col3 = sin(color_timer * coords[3]) * 127 + 128;
 
-			poly.g4->color[0].r = col0;
-			poly.g4->color[0].g = col0;
-			poly.g4->color[0].b = 255;
-			poly.g4->color[0].a = shield_alpha;
-
-			poly.g4->color[1].r = col1;
-			poly.g4->color[1].g = col1;
-			poly.g4->color[1].b = 255;
-			poly.g4->color[1].a = shield_alpha;
-
-			poly.g4->color[2].r = col2;
-			poly.g4->color[2].g = col2;
-			poly.g4->color[2].b = 255;
-			poly.g4->color[2].a = shield_alpha;
-
-			poly.g4->color[3].r = col3;
-			poly.g4->color[3].g = col3;
-			poly.g4->color[3].b = 255;
-			poly.g4->color[3].a = shield_alpha;
+			poly.g4->color[0] = rgba(col0, col0, 255, shield_alpha);
+			poly.g4->color[1] = rgba(col1, col1, 255, shield_alpha);
+			poly.g4->color[2] = rgba(col2, col2, 255, shield_alpha);
+			poly.g4->color[3] = rgba(col3, col3, 255, shield_alpha);
 			poly.g4 += 1;
 			break;
 		}


### PR DESCRIPTION
In penance for the code my other requests add, this commit condenses away 70 lines of code using the `rgba()` macro.
The only semantic difference is that the alpha gets set explicitly to `0xFF` in some cases where it used to be unset, but I don't expect that to cause any problems - if it does, it's straightforward to fix. All the lighting does *appear* to be correct, to my eye.

Replacement for #176.