### PR TITLE
Simplifying more vector math

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -42,7 +42,7 @@ typedef union {
 		union {
 			vec3_t vec3;
 			vec4_t vec4;
-		} x, y, z, w;
+		} right, down, forward, translation;
 	} basis;
 } mat4_t;
 

--- a/src/wipeout/camera.c
+++ b/src/wipeout/camera.c
@@ -28,7 +28,7 @@ void camera_init(camera_t *camera, section_t *section) {
 vec3_t camera_forward(camera_t *camera) {
 	mat4_t rotation_matrix;
 	mat4_set_yaw_pitch_roll(&rotation_matrix, camera->angle);
-	return rotation_matrix.basis.z.vec3;
+	return rotation_matrix.basis.forward.vec3;
 }
 
 void camera_update(camera_t *camera, ship_t *ship, droid_t *droid) {
@@ -39,7 +39,9 @@ void camera_update(camera_t *camera, ship_t *ship, droid_t *droid) {
 }
 
 void camera_update_race_external(camera_t *camera, ship_t *ship, droid_t *droid) {
-	vec3_t pos = vec3_sub(ship->position, vec3_mulf(ship->dir_forward, 1024));
+	
+	vec3_t pos = vec3_transform(vec3(0,0,-1024), &ship->mat);
+	
 	pos.y -= 200;
 	camera->section = track_nearest_section(pos, vec3(1,1,1), camera->section, NULL);
 	section_t *next = camera->section->next;
@@ -66,8 +68,8 @@ void camera_update_race_internal(camera_t *camera, ship_t *ship, droid_t *droid)
 
 void camera_update_race_intro(camera_t *camera, ship_t *ship, droid_t *droid) {
 	// Set to final position
-	vec3_t pos = vec3_sub(ship->position, vec3_mulf(ship->dir_forward, 0.25 * 4096));
-
+	vec3_t pos = vec3_transform(vec3(0,0,-0.25 * 4096), &ship->mat);
+	
 	pos.x += sin(( (ship->update_timer - UPDATE_TIME_RACE_VIEW) * 30 * 3.0 * M_PI * 2) / 4096.0) * 4096;
 	pos.y -= (2 *  (ship->update_timer - UPDATE_TIME_RACE_VIEW) * 30) + 200;
 	pos.z += sin(( (ship->update_timer - UPDATE_TIME_RACE_VIEW) * 30 * 3.0 * M_PI * 2) / 4096.0) * 4096;
@@ -109,8 +111,8 @@ void camera_update_attract_circle(camera_t *camera, ship_t *ship, droid_t *droid
 	camera->position.x += sin(camera->update_timer * 0.25) * 512;
 	camera->position.y -= 400;
 	camera->position.z += cos(camera->update_timer * 0.25) * 512;
-	camera->position = vec3_sub(camera->position, vec3_mulf(ship->dir_up, 256));
-
+	camera->position = vec3_add(camera->position, vec3_mulf(ship->mat.basis.down.vec3, 256));
+	
 	vec3_t target = vec3_sub(ship->position, camera->position);
 	float height = sqrt(target.x * target.x + target.z * target.z);
 	camera->angle.x = -atan2(target.y, height);

--- a/src/wipeout/droid.c
+++ b/src/wipeout/droid.c
@@ -113,16 +113,14 @@ void droid_update_intro(droid_t *droid, ship_t *ship) {
 	droid->update_timer -= system_tick();
 
 	if (droid->update_timer < DROID_UPDATE_TIME_INTRO_3) {
-		droid->acceleration.x = (-sin(droid->angle.y) * cos(droid->angle.x)) * 0.25 * 4096.0;
+		droid->acceleration = vec3_mulf(droid->mat.basis.forward.vec3, 0.25 * 4096.0);
 		droid->acceleration.y = 0;
-		droid->acceleration.z = (cos(droid->angle.y) * cos(droid->angle.x)) * 0.25 * 4096.0;
 		droid->angular_velocity.y = 0;
 	}
 
 	else if (droid->update_timer < DROID_UPDATE_TIME_INTRO_2) {
-		droid->acceleration.x = (-sin(droid->angle.y) * cos(droid->angle.x)) * 0.125 * 4096.0;
+		droid->acceleration = vec3_mulf(droid->mat.basis.forward.vec3, 0.125 * 4096.0);
 		droid->acceleration.y = -140;
-		droid->acceleration.z = (cos(droid->angle.y) * cos(droid->angle.x)) * 0.125 * 4096.0;
 		droid->angular_velocity.y = (-8.0 / 4096.0) * M_PI * 2 * 30;
 	}
 
@@ -136,7 +134,7 @@ void droid_update_intro(droid_t *droid, ship_t *ship) {
 		// as soon as the intro completes.
 		if (!droid->section) {
 			// Zeroing these is not strictly needed but seems like a good idea
-			droid->velocity = droid->acceleration = droid->angular_velocity = (const vec3_t){ 0 };
+			droid->velocity = droid->acceleration = droid->angular_velocity = vec3(0,0,0);
 			droid->update_func = droid_update_nothing;
 			return;
 		}
@@ -176,9 +174,8 @@ void droid_update_idle(droid_t *droid, ship_t *ship) {
 		droid->angular_velocity.y = quickest_turn * 30.0 / 64.0;
 	}
 
-	droid->acceleration.x = (-sin(droid->angle.y) * cos(droid->angle.x)) * 0.125 * 4096;
+	droid->acceleration = vec3_mulf(droid->mat.basis.forward.vec3, 0.125 * 4096.0);
 	droid->acceleration.y = target_vector.y / 64.0;
-	droid->acceleration.z = (cos(droid->angle.y) * cos(droid->angle.x)) * 0.125 * 4096;
 
 	if (flags_is(ship->flags, SHIP_IN_RESCUE)) {
 		flags_add(droid->sfx_tractor->flags, SFX_PLAY);

--- a/src/wipeout/ship.c
+++ b/src/wipeout/ship.c
@@ -409,9 +409,9 @@ void ship_draw_shadow(ship_t *self) {
 	track_face_t *face = track_section_get_base_face(self->section);
 
 	vec3_t face_point = face->tris[0].vertices[0].pos;
-	vec3_t nose = vec3_add(self->position, vec3_mulf(self->dir_forward, 384));
-	vec3_t wngl = vec3_sub(vec3_sub(self->position, vec3_mulf(self->dir_right, 256)), vec3_mulf(self->dir_forward, 384));
-	vec3_t wngr = vec3_sub(vec3_add(self->position, vec3_mulf(self->dir_right, 256)), vec3_mulf(self->dir_forward, 384));
+	vec3_t nose = vec3_transform(vec3( 0,   0,  384), &self->mat);
+	vec3_t wngl = vec3_transform(vec3(-256, 0, -384), &self->mat);
+	vec3_t wngr = vec3_transform(vec3( 256, 0, -384), &self->mat);
 
 	nose = vec3_sub(nose, vec3_mulf(face->normal, vec3_distance_to_plane(nose, face_point, face->normal)));
 	wngl = vec3_sub(wngl, vec3_mulf(face->normal, vec3_distance_to_plane(wngl, face_point, face->normal)));
@@ -440,12 +440,6 @@ void ship_draw_shadow(ship_t *self) {
 }
 
 void ship_update(ship_t *self) {
-	mat4_t rotation_matrix;
-	mat4_set_yaw_pitch_roll(&rotation_matrix, self->angle);
-	self->dir_right   = rotation_matrix.basis.x.vec3;
-	self->dir_up      = vec3_mulf(rotation_matrix.basis.y.vec3, -1);
-	self->dir_forward = rotation_matrix.basis.z.vec3;
-
 	self->prev_section = self->section;
 
 	// To find the nearest section to the ship, the original source de-emphasizes
@@ -581,20 +575,19 @@ void ship_update(ship_t *self) {
 }
 
 vec3_t ship_cockpit(ship_t *self) {
-	return vec3_add(self->position, vec3_mulf(self->dir_up, 128));
+	return vec3_transform(vec3(0, -128, 0), &self->mat);
 }
 
 vec3_t ship_nose(ship_t *self) {
-	return vec3_add(self->position, vec3_mulf(self->dir_forward, 512));
-	
+	return vec3_transform(vec3(0, 0, 512), &self->mat);
 }
 
 vec3_t ship_wing_left(ship_t *self) {
-	return vec3_sub(vec3_sub(self->position, vec3_mulf(self->dir_right, 256)), vec3_mulf(self->dir_forward, 256));
+	return vec3_transform(vec3(-256, 0, -256), &self->mat);
 }
 
 vec3_t ship_wing_right(ship_t *self) {
-	return vec3_sub(vec3_add(self->position, vec3_mulf(self->dir_right, 256)), vec3_mulf(self->dir_forward, 256));
+	return vec3_transform(vec3(256, 0, -256), &self->mat);
 }
 
 static bool vec3_is_on_face(vec3_t pos, track_face_t *face, float alpha) {
@@ -615,7 +608,7 @@ static bool vec3_is_on_face(vec3_t pos, track_face_t *face, float alpha) {
 
 void ship_resolve_wing_collision(ship_t *self, track_face_t *face, float direction) {
 	vec3_t collision_vector = vec3_sub(self->section->center, face->tris[0].vertices[2].pos);
-	float angle = vec3_angle(collision_vector, self->dir_forward);
+	float angle = vec3_angle(collision_vector, self->mat.basis.forward.vec3);
 	self->velocity = vec3_reflect(self->velocity, face->normal, 2);
 	self->position = vec3_sub(self->position, vec3_mulf(self->velocity, 0.015625)); // system_tick?
 	self->velocity = vec3_sub(self->velocity, vec3_mulf(self->velocity, 0.5));
@@ -626,11 +619,11 @@ void ship_resolve_wing_collision(ship_t *self, track_face_t *face, float directi
 	vec3_t wing_pos;
 	if (direction > 0) {
 		self->angular_velocity.z += magnitude;
-		wing_pos = vec3_add(self->position, vec3_mulf(vec3_sub(self->dir_right, self->dir_forward), 256)); // >> 4??
+		wing_pos = ship_wing_right(self);
 	}
 	else {
 		self->angular_velocity.z -= magnitude;	
-		wing_pos = vec3_sub(self->position, vec3_mulf(vec3_sub(self->dir_right, self->dir_forward), 256)); // >> 4??
+		wing_pos = ship_wing_left(self);
 	}
 
 	if (self->last_impact_time > 0.2) {
@@ -642,7 +635,7 @@ void ship_resolve_wing_collision(ship_t *self, track_face_t *face, float directi
 
 void ship_resolve_nose_collision(ship_t *self, track_face_t *face, float direction) {
 	vec3_t collision_vector = vec3_sub(self->section->center, face->tris[0].vertices[2].pos);
-	float angle = vec3_angle(collision_vector, self->dir_forward);
+	float angle = vec3_angle(collision_vector, self->mat.basis.forward.vec3);
 	self->velocity = vec3_reflect(self->velocity, face->normal, 2);
 	self->position = vec3_sub(self->position, vec3_mulf(self->velocity, 0.015625)); // system_tick?
 	self->velocity = vec3_sub(self->velocity, vec3_mulf(self->velocity, 0.5));
@@ -671,7 +664,7 @@ void ship_collide_with_track(ship_t *self, track_face_t *face) {
 
 	trackPtr = self->section->next;
 	vec3_t direction = vec3_sub(trackPtr->center, self->section->center);
-	float down_track = vec3_dot(direction, self->dir_forward);
+	float down_track = vec3_dot(direction, self->mat.basis.forward.vec3);
 
 	if (down_track < 0) {
 		flags_rm(self->flags, SHIP_DIRECTION_FORWARD);

--- a/src/wipeout/ship.h
+++ b/src/wipeout/ship.h
@@ -66,10 +66,6 @@ typedef struct ship_t {
 
 	section_t *section, *prev_section;
 
-	vec3_t dir_forward;
-	vec3_t dir_right;
-	vec3_t dir_up;
-
 	vec3_t position;
 	vec3_t velocity;
 	vec3_t acceleration;

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -300,9 +300,9 @@ void ship_player_update_race(ship_t *self) {
 	// Physics
 
 	// Calculate thrust vector along principle axis of ship
-	self->thrust = vec3_mulf(self->dir_forward, self->thrust_mag * 64);
+	self->thrust = vec3_mulf(self->mat.basis.forward.vec3, self->thrust_mag * 64);
 	self->speed = vec3_len(self->velocity);
-	vec3_t forward_velocity = vec3_mulf(self->dir_forward, self->speed);
+	vec3_t forward_velocity = vec3_mulf(self->mat.basis.forward.vec3, self->speed);
 
 	// SECTION_JUMP
 	if (flags_is(self->section->flags, SECTION_JUMP)) {
@@ -383,7 +383,8 @@ void ship_player_update_race(ship_t *self) {
 		self->acceleration = vec3_sub(self->acceleration, vec3_divf(self->velocity, resistance));
 
 		// Burying the nose in the track? Move it out!
-		vec3_t nose_pos = vec3_add(self->position, vec3_mulf(self->dir_forward, 128));
+		// Why is it 128 units in front? ship_nose() puts it at 512...
+		vec3_t nose_pos = vec3_transform(vec3(0, 0, 128), &self->mat);
 		float nose_height = vec3_distance_to_plane(nose_pos,face_point, face->normal);
 		if (nose_height < 600) {
 			self->angular_acceleration.x += NTSC_ACCELERATION(ANGLE_NORM_TO_RADIAN(FIXED_TO_FLOAT((height - nose_height + 5) * (1.0/16.0))));

--- a/src/wipeout/weapon.c
+++ b/src/wipeout/weapon.c
@@ -237,7 +237,8 @@ void weapon_set_trajectory(weapon_t *self) {
 	track_face_t *face = track_section_get_base_face(ship->section);
 
 	vec3_t face_point = face->tris[0].vertices[0].pos;
-	vec3_t target = vec3_add(ship->position, vec3_mulf(ship->dir_forward, 64));
+	vec3_t target = vec3_transform(vec3(0,0,64), &ship->mat);
+	
 	float target_height = vec3_distance_to_plane(target, face_point, face->normal);
 	float ship_height = vec3_distance_to_plane(target, face_point, face->normal);
 
@@ -263,7 +264,7 @@ void weapon_follow_target(weapon_t *self) {
 
 	mat4_t rotation_matrix;
 	mat4_set_yaw_pitch_roll(&rotation_matrix, self->angle);
-	self->acceleration = vec3_mulf(rotation_matrix.basis.z.vec3, 256);
+	self->acceleration = vec3_mulf(rotation_matrix.basis.forward.vec3, 256);
 }
 
 ship_t *weapon_collides_with_ship(weapon_t *self) {
@@ -606,7 +607,7 @@ void weapon_update_shield(weapon_t *self) {
 
 
 void weapon_fire_turbo(ship_t *ship) {
-	ship->velocity = vec3_add(ship->velocity, vec3_mulf(ship->dir_forward, 39321)); // unitVecNose.vx) << 3) * FR60) / 50
+	ship->velocity = vec3_add(ship->velocity, vec3_mulf(ship->mat.basis.forward.vec3, 39321)); // unitVecNose.vx) << 3) * FR60) / 50
 	
 	if (ship->pilot == g.pilot) {
 		sfx_t *sfx = sfx_play(SFX_MISSILE_FIRE);


### PR DESCRIPTION
I yearn for [cglm](https://github.com/recp/cglm/tree/master)... anyhow, `ship.dir_*` is redundant, we already have a matrix we can use. I'll admit that `mat.basis.forward.vec3` is less clear than `dir_forward`, but some other code is a lot *more* clear, now.

As usual my testing for these changes consists of squinting at the diff and the running game. I'm not sure what else I could do - maybe hardcode the `srand` seed and delta so the game is deterministic, and check if my changes diverge?

I've found the idiosyncratic "X-right Y-down Z-forward" coordinate system to be quite the tripping hazard.