### PR TITLE
Assorted simplifications

### DIFF
--- a/src/types.c
+++ b/src/types.c
@@ -64,6 +64,14 @@ vec3_t vec3_reflect(vec3_t incidence, vec3_t normal, float f) {
 	return vec3_add(incidence, vec3_mulf(normal, vec3_dot(normal, vec3_mulf(incidence, -1)) * f));
 }
 
+vec3_t vec3_rand(float maxlen) {
+	vec3_t v;
+	do {
+		v = vec3(rand_float(-maxlen, maxlen), rand_float(-maxlen, maxlen), rand_float(-maxlen, maxlen));
+	} while (vec3_len(v) > maxlen);
+	return v;
+}
+
 void mat4_set_translation(mat4_t *mat, vec3_t pos) {
 	mat->cols[3][0] = pos.x;
 	mat->cols[3][1] = pos.y;

--- a/src/types.h
+++ b/src/types.h
@@ -245,6 +245,7 @@ vec3_t vec3_normalize(vec3_t a);
 vec3_t vec3_project_to_ray(vec3_t p, vec3_t r0, vec3_t r1);
 float vec3_distance_to_plane(vec3_t p, vec3_t plane_pos, vec3_t plane_normal);
 vec3_t vec3_reflect(vec3_t incidence, vec3_t normal, float f);
+vec3_t vec3_rand(float maxlen);
 
 float wrap_angle(float a);
 

--- a/src/wipeout/scene.c
+++ b/src/wipeout/scene.c
@@ -174,21 +174,16 @@ void scene_set_start_booms(int light_index) {
 	
 	int lights_len = 1;
 	rgba_t color = rgba(0, 0, 0, 0);
-
-	if (light_index == 0) { // reset all 3
-		lights_len = 3;
-		color = rgba(0x20, 0x20, 0x20, 0xff);
+	switch (light_index) {
+		case 0:
+			// reset all 3
+			lights_len = 3;
+			color = rgba(0x20, 0x20, 0x20, 0xff);
+			break;
+		case 1: color = rgba(0xff, 0x00, 0x00, 0xff); break;
+		case 2: color = rgba(0xff, 0x80, 0x00, 0xff); break;
+		case 3: color = rgba(0x00, 0xff, 0x00, 0xff); break;
 	}
-	else if (light_index == 1) {
-		color = rgba(0xff, 0x00, 0x00, 0xff);
-	}
-	else if (light_index == 2) {
-		color = rgba(0xff, 0x80, 0x00, 0xff);
-	}
-	else if (light_index == 3) {
-		color = rgba(0x00, 0xff, 0x00, 0xff);
-	}
-
 	for (int i = 0; i < start_booms_len; i++) {
 		Prm libPoly = {.primitive = start_booms[i]->primitives};
 

--- a/src/wipeout/ship.c
+++ b/src/wipeout/ship.c
@@ -389,14 +389,10 @@ void ship_init_exhaust_plume(ship_t *self) {
 	}
 }
 
-void ship_reset_exhaust_plume(ship_t* self)
-{
+void ship_reset_exhaust_plume(ship_t* self) {
 	for (int i = 0; i < 3; i++) {
-		if (self->exhaust_plume[i].v != NULL) {
-			self->exhaust_plume[i].v->z = self->exhaust_plume[i].initial.z;
-			self->exhaust_plume[i].v->x = self->exhaust_plume[i].initial.x;
-			self->exhaust_plume[i].v->y = self->exhaust_plume[i].initial.y;
-		}
+		if (self->exhaust_plume[i].v)
+			*self->exhaust_plume[i].v = self->exhaust_plume[i].initial;
 	}
 }
 
@@ -847,8 +843,7 @@ void ship_collide_with_track(ship_t *self, track_face_t *face) {
 
 
 bool ship_intersects_ship(ship_t *self, ship_t *other) {
-	// Get 4 points of collision model relative to the
-	// camera
+	// Get 4 points of collision model in world space
 	vec3_t a = vec3_transform(other->collision_model->vertices[0], &other->mat);
 	vec3_t b = vec3_transform(other->collision_model->vertices[1], &other->mat);
 	vec3_t c = vec3_transform(other->collision_model->vertices[2], &other->mat);
@@ -875,36 +870,18 @@ bool ship_intersects_ship(ship_t *self, ship_t *other) {
 		int16_t *indices;
 		switch (poly.primitive->type) {
 			case PRM_TYPE_F3:
-				indices = poly.f3->coords;
-				p1 =  vec3_transform(self->collision_model->vertices[indices[0]], &self->mat);
-				p2 =  vec3_transform(self->collision_model->vertices[indices[1]], &self->mat);
-				p3 =  vec3_transform(self->collision_model->vertices[indices[2]], &self->mat);
-				poly.f3++;
-				break;
+				indices = poly.f3++->coords;  break;
 			case PRM_TYPE_G3:
-				indices = poly.g3->coords;
-				p1 =  vec3_transform(self->collision_model->vertices[indices[0]], &self->mat);
-				p2 =  vec3_transform(self->collision_model->vertices[indices[1]], &self->mat);
-				p3 =  vec3_transform(self->collision_model->vertices[indices[2]], &self->mat);
-				poly.g3++;
-				break;
+				indices = poly.g3++->coords;  break;
 			case PRM_TYPE_FT3:
-				indices = poly.ft3->coords;
-				p1 =  vec3_transform(self->collision_model->vertices[indices[0]], &self->mat);
-				p2 =  vec3_transform(self->collision_model->vertices[indices[1]], &self->mat);
-				p3 =  vec3_transform(self->collision_model->vertices[indices[2]], &self->mat);
-				poly.ft3++;
-				break;
+				indices = poly.ft3++->coords; break;
 			case PRM_TYPE_GT3:
-				indices = poly.gt3->coords;
-				p1 =  vec3_transform(self->collision_model->vertices[indices[0]], &self->mat);
-				p2 =  vec3_transform(self->collision_model->vertices[indices[1]], &self->mat);
-				p3 =  vec3_transform(self->collision_model->vertices[indices[2]], &self->mat);
-				poly.gt3++;
-				break;
-			default:
-				break;
+				indices = poly.gt3++->coords; break;
+			default: die("Can't happen?");
 		}
+		p1 =  vec3_transform(self->collision_model->vertices[indices[0]], &self->mat);
+		p2 =  vec3_transform(self->collision_model->vertices[indices[1]], &self->mat);
+		p3 =  vec3_transform(self->collision_model->vertices[indices[2]], &self->mat);
 
 		// Find polyGon line vectors
 		vec3_t p1p2 = vec3_sub(p2, p1);

--- a/src/wipeout/ship_ai.c
+++ b/src/wipeout/ship_ai.c
@@ -121,12 +121,10 @@ void ship_ai_update_race(ship_t *self) {
 
 	ship_t *player = &(g.ships[g.pilot]);
 
-	if (self->ebolt_timer > 0) {
+	if (self->ebolt_timer > 0)
 		self->ebolt_timer -= system_tick();
-	}
-	if (self->ebolt_timer <= 0) {
+	else
 		flags_rm(self->flags, SHIP_ELECTROED);
-	}
 
 	int behind_speed = def.circuts[g.circut].settings[g.race_class].behind_speed;
 
@@ -246,33 +244,25 @@ void ship_ai_update_race(ship_t *self) {
 
 							if (chance < 48) {
 								self->update_strat_func = ship_ai_strat_block;
-							}
-							else if ((chance >= 40) && (chance < 54)) {
+							} else {
 								self->update_strat_func = ship_ai_strat_avoid;
 								flags_rm(self->flags, SHIP_OVERTAKEN);
+								
 								if (flags_not(self->flags, SHIP_SHIELDED) && flags_is(self->flags, SHIP_RACING)) {
-									sfx_play(SFX_VOICE_ROCKETS);
-									self->weapon_type = WEAPON_TYPE_ROCKET;
-									weapons_fire_delayed(self, self->weapon_type);
-								}
-							}
-							else if ((chance >= 54) && (chance < 60)) {
-								self->update_strat_func = ship_ai_strat_avoid;
-								flags_rm(self->flags, SHIP_OVERTAKEN);
-								if (flags_not(self->flags, SHIP_SHIELDED) && flags_is(self->flags, SHIP_RACING)) {
-									sfx_play(SFX_VOICE_MISSILE);
-									self->weapon_type = WEAPON_TYPE_MISSILE;
-									self->weapon_target = &g.ships[g.pilot];
-									weapons_fire_delayed(self, self->weapon_type);
-								}
-							}
-							else if ((chance >= 60) && (chance < 64)) {
-								self->update_strat_func = ship_ai_strat_avoid;
-								flags_rm(self->flags, SHIP_OVERTAKEN);
-								if (flags_not(self->flags, SHIP_SHIELDED) && flags_is(self->flags, SHIP_RACING)) {
-									sfx_play(SFX_VOICE_SHOCKWAVE);
-									self->weapon_type = WEAPON_TYPE_EBOLT;
-									self->weapon_target = &g.ships[g.pilot];
+									if (chance < 54) {
+										sfx_play(SFX_VOICE_ROCKETS);
+										self->weapon_type = WEAPON_TYPE_ROCKET;
+									}
+									else if (chance < 60) {
+										sfx_play(SFX_VOICE_MISSILE);
+										self->weapon_type = WEAPON_TYPE_MISSILE;
+										self->weapon_target = &g.ships[g.pilot];
+									}
+									else {
+										sfx_play(SFX_VOICE_SHOCKWAVE);
+										self->weapon_type = WEAPON_TYPE_EBOLT;
+										self->weapon_target = &g.ships[g.pilot];
+									}
 									weapons_fire_delayed(self, self->weapon_type);
 								}
 							}
@@ -400,20 +390,12 @@ void ship_ai_update_race(ship_t *self) {
 		section = self->section->prev;
 
 		for (int i = 0; i < 4; i++) {
-			if (section->junction) {
-				if (flags_is(section->junction->flags, SECTION_JUNCTION_START)) {
-					if (flags_is(self->flags, SHIP_JUNCTION_LEFT)) {
-						section = section->junction;
-					}
-					else {
-						section = section->next;
-					}
-				}
-				else {
-					section = section->next;
-				}
-			}
-			else {
+			if (section->junction &&
+				flags_is(section->junction->flags, SECTION_JUNCTION_START) &&
+				flags_is(self->flags, SHIP_JUNCTION_LEFT)
+			) {
+				section = section->junction;
+			} else {
 				section = section->next;
 			}
 		}
@@ -530,7 +512,7 @@ void ship_ai_update_race(ship_t *self) {
 		if (self->ebolt_effect_timer > 0.1) {
 			self->ebolt_effect_timer -= 0.1;
 
-			self->position = vec3_add(self->position, vec3(rand_float(-20, 20), rand_float(-20, 20), rand_float(-20, 20)));
+			self->position = vec3_add(self->position, vec3_rand(20));
 
 			if (rand_int(0, 10) == 0) {
 				self->speed -= self->speed * 0.5;

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -148,29 +148,20 @@ void ship_player_update_race(ship_t *self) {
 		return;
 	}
 
-	if (self->ebolt_timer > 0) {
+	if (self->ebolt_timer > 0)
 		self->ebolt_timer -= system_tick();
-	}
-
-	if (self->ebolt_timer <= 0) {
+	else
 		flags_rm(self->flags, SHIP_ELECTROED);
-	}
 
-	if (self->revcon_timer > 0) {
+	if (self->revcon_timer > 0)
 		self->revcon_timer -= system_tick();
-	}
-
-	if (self->revcon_timer <= 0) {
+	else
 		flags_rm(self->flags, SHIP_REVCONNED);
-	}
 
-	if (self->special_timer > 0) {
+	if (self->special_timer > 0)
 		self->special_timer -= system_tick();
-	}
-
-	if (self->special_timer <= 0) {
+	else
 		flags_rm(self->flags, SHIP_SPECIALED);
-	}
 
 	if (flags_is(self->flags, SHIP_REVCONNED)) {
 		// FIXME_PL: make sure revconned is honored
@@ -219,7 +210,7 @@ void ship_player_update_race(ship_t *self) {
 			self->angular_velocity.y += rand_float(-0.5, 0.5);
 
 			if (rand_int(0, 10) == 0) { // approx once per second
-				self->thrust_mag -= self->thrust_mag * 0.25;
+				self->thrust_mag *= 0.75;
 			}
 		}
 	}

--- a/src/wipeout/weapon.c
+++ b/src/wipeout/weapon.c
@@ -189,7 +189,7 @@ void weapons_update(void) {
 				weapon->trail_spawn_timer += system_tick();
 				while (weapon->trail_spawn_timer > 0) {
 					vec3_t pos = vec3_sub(weapon->position, vec3_mulf(weapon->velocity, 30 * system_tick() * weapon->trail_spawn_timer));
-					vec3_t velocity = vec3(rand_float(-128, 128), rand_float(-128, 128), rand_float(-128, 128));
+					vec3_t velocity = vec3_rand(128);
 					particles_spawn(pos, weapon->trail_particle, velocity, 128);
 					weapon->trail_spawn_timer -= WEAPON_PARTICLE_SPAWN_RATE;
 				}
@@ -199,7 +199,7 @@ void weapons_update(void) {
 			weapon->section = track_nearest_section(weapon->position, vec3(1,1,1), weapon->section, NULL);
 			if (weapon_collides_with_track(weapon)) {
 				for (int p = 0; p < 32; p++) {
-					vec3_t velocity = vec3(rand_float(-512, 512), rand_float(-512, 512), rand_float(-512, 512));
+					vec3_t velocity = vec3_rand(512);
 					particles_spawn(weapon->position, weapon->track_hit_particle, velocity, 256);
 				}
 				sfx_play_at(SFX_EXPLOSION_2, weapon->position, vec3(0,0,0), 1);
@@ -277,7 +277,7 @@ ship_t *weapon_collides_with_ship(weapon_t *self) {
 		float distance = vec3_len(vec3_sub(ship->position, self->position));
 		if (distance < 512) {
 			for (int p = 0; p < 32; p++) {
-				vec3_t velocity = vec3(rand_float(-512, 512), rand_float(-512, 512), rand_float(-512, 512));
+				vec3_t velocity = vec3_rand(512);
 				velocity = vec3_add(velocity, vec3_mulf(ship->velocity, 0.25));
 				particles_spawn(self->position, self->ship_hit_particle, velocity, 256);
 			}


### PR DESCRIPTION
These are miscellaneous changes I couldn't categorise. A lot of it is just reorganizing conditionals to be shorter. I have made the nesting in `ship_ai_update_race` even worse, it probably needs to be broken up. 

In the absence of a style guide I've gone for the most terse code possible. Potentially a bad idea, if / else with no braces guarding them may not be kosher, even if it *is* legal.

None of this should change behaviour, with the exception of `vec3_rand`. It generates random vectors in a sphere, instead of an axis-aligned cube. This is probably pedantic and irrelevant. In a situation where someone might make out the distribution, it *would* look less jank, though. 

`vec3_rand` does rejection sampling: Every loop has a ~52.4% chance of success, so it'll only need more than 7 iterations 0.5% of the time. There are algorithms that don't loop like this, but they're more complicated and invoke `pow()`, most certainly not worth it unless you're working in the sixth dimension.