### PR TITLE
Change double precision math functions to single precision

### DIFF
--- a/src/types.c
+++ b/src/types.c
@@ -16,14 +16,14 @@ vec3_t vec3_wrap_angle(vec3_t a) {
 }
 
 float vec3_angle(vec3_t a, vec3_t b) {
-	float magnitude = sqrt(
+	float magnitude = sqrtf(
 		(a.x * a.x + a.y * a.y + a.z * a.z) * 
 		(b.x * b.x + b.y * b.y + b.z * b.z)
 	);
 	float cosine = (magnitude == 0)
 		? 1
 		: vec3_dot(a, b) / magnitude;
-	return acos(clamp(cosine, -1, 1));
+	return acosf(clamp(cosine, -1, 1));
 }
 
 vec3_t vec3_transform(vec3_t a, mat4_t *mat) {
@@ -71,12 +71,12 @@ void mat4_set_translation(mat4_t *mat, vec3_t pos) {
 }
 
 void mat4_set_yaw_pitch_roll(mat4_t *mat, vec3_t rot) {
-	float sx = sin( rot.x);
-	float sy = sin(-rot.y);
-	float sz = sin(-rot.z);
-	float cx = cos( rot.x);
-	float cy = cos(-rot.y);
-	float cz = cos(-rot.z);
+	float sx = sinf( rot.x);
+	float sy = sinf(-rot.y);
+	float sz = sinf(-rot.z);
+	float cx = cosf( rot.x);
+	float cy = cosf(-rot.y);
+	float cz = cosf(-rot.z);
 
 	mat->cols[0][0] = cy * cz + sx * sy * sz;
 	mat->cols[1][0] = cz * sx * sy - cy * sz;
@@ -90,12 +90,12 @@ void mat4_set_yaw_pitch_roll(mat4_t *mat, vec3_t rot) {
 }
 
 void mat4_set_roll_pitch_yaw(mat4_t *mat, vec3_t rot) {
-	float sx = sin( rot.x);
-	float sy = sin(-rot.y);
-	float sz = sin(-rot.z);
-	float cx = cos( rot.x);
-	float cy = cos(-rot.y);
-	float cz = cos(-rot.z);
+	float sx = sinf( rot.x);
+	float sy = sinf(-rot.y);
+	float sz = sinf(-rot.z);
+	float cx = cosf( rot.x);
+	float cy = cosf(-rot.y);
+	float cz = cosf(-rot.z);
 
 	mat->cols[0][0] = cy * cz - sx * sy * sz;
 	mat->cols[1][0] = -cx * sz;

--- a/src/types.h
+++ b/src/types.h
@@ -158,7 +158,7 @@ static inline vec3_t vec3_divf(vec3_t a, float f) {
 }
 
 static inline float vec3_len(vec3_t a) {
-	return sqrt(a.x * a.x + a.y * a.y + a.z * a.z);
+	return sqrtf(a.x * a.x + a.y * a.y + a.z * a.z);
 }
 
 static inline vec3_t vec3_cross(vec3_t a, vec3_t b) {

--- a/src/wipeout/camera.c
+++ b/src/wipeout/camera.c
@@ -70,9 +70,9 @@ void camera_update_race_intro(camera_t *camera, ship_t *ship, droid_t *droid) {
 	// Set to final position
 	vec3_t pos = vec3_transform(vec3(0,0,-0.25 * 4096), &ship->mat);
 	
-	pos.x += sin(( (ship->update_timer - UPDATE_TIME_RACE_VIEW) * 30 * 3.0 * M_PI * 2) / 4096.0) * 4096;
+	pos.x += sinf(( (ship->update_timer - UPDATE_TIME_RACE_VIEW) * 30 * 3.0 * M_PI * 2) / 4096.0) * 4096;
 	pos.y -= (2 *  (ship->update_timer - UPDATE_TIME_RACE_VIEW) * 30) + 200;
-	pos.z += sin(( (ship->update_timer - UPDATE_TIME_RACE_VIEW) * 30 * 3.0 * M_PI * 2) / 4096.0) * 4096;
+	pos.z += sinf(( (ship->update_timer - UPDATE_TIME_RACE_VIEW) * 30 * 3.0 * M_PI * 2) / 4096.0) * 4096;
 
 	if (!camera->has_initial_section) {
 		camera->section = ship->section;
@@ -87,7 +87,7 @@ void camera_update_race_intro(camera_t *camera, ship_t *ship, droid_t *droid) {
 	camera->angle.x = ship->angle.x * 0.5;
 	vec3_t target = vec3_sub(ship->position, pos);
 
-	camera->angle.y = -atan2(target.x, target.z);
+	camera->angle.y = -atan2f(target.x, target.z);
 
 	if (ship->update_timer <= UPDATE_TIME_RACE_VIEW) {
 		flags_add(ship->flags, SHIP_VIEW_INTERNAL);
@@ -104,28 +104,28 @@ void camera_update_attract_circle(camera_t *camera, ship_t *ship, droid_t *droid
 	// differently.
 	camera->section = ship->section;
 
-	camera->position.x = ship->position.x + sin(ship->angle.y) * 512;
+	camera->position.x = ship->position.x + sinf(ship->angle.y) * 512;
 	camera->position.y = ship->position.y + ((ship->angle.x * 512 / (M_PI * 2)) - 200);
-	camera->position.z = ship->position.z - cos(ship->angle.y) * 512;
+	camera->position.z = ship->position.z - cosf(ship->angle.y) * 512;
 
-	camera->position.x += sin(camera->update_timer * 0.25) * 512;
+	camera->position.x += sinf(camera->update_timer * 0.25) * 512;
 	camera->position.y -= 400;
-	camera->position.z += cos(camera->update_timer * 0.25) * 512;
+	camera->position.z += cosf(camera->update_timer * 0.25) * 512;
 	camera->position = vec3_add(camera->position, vec3_mulf(ship->mat.basis.down.vec3, 256));
 	
 	vec3_t target = vec3_sub(ship->position, camera->position);
-	float height = sqrt(target.x * target.x + target.z * target.z);
-	camera->angle.x = -atan2(target.y, height);
-	camera->angle.y = -atan2(target.x, target.z);
+	float height = sqrtf(target.x * target.x + target.z * target.z);
+	camera->angle.x = -atan2f(target.y, height);
+	camera->angle.y = -atan2f(target.x, target.z);
 }
 
 void camera_update_rescue(camera_t *camera, ship_t *ship, droid_t *droid) {
 	camera->position = vec3_add(camera->section->center, vec3(300, -1500, 300));
 
 	vec3_t target = vec3_sub(droid->position, camera->position);
-	float height = sqrt(target.x * target.x + target.z * target.z);
-	camera->angle.x = -atan2(target.y, height);
-	camera->angle.y = -atan2(target.x, target.z);
+	float height = sqrtf(target.x * target.x + target.z * target.z);
+	camera->angle.x = -atan2f(target.y, height);
+	camera->angle.y = -atan2f(target.x, target.z);
 }
 
 
@@ -147,9 +147,9 @@ void camera_update_static_follow(camera_t *camera, ship_t *ship, droid_t *droid)
 	}
 
 	vec3_t target = vec3_sub(ship->position, camera->position);
-	float height = sqrt(target.x * target.x + target.z * target.z);
-	camera->angle.x = -atan2(target.y, height);
-	camera->angle.y = -atan2(target.x, target.z);
+	float height = sqrtf(target.x * target.x + target.z * target.z);
+	camera->angle.x = -atan2f(target.y, height);
+	camera->angle.y = -atan2f(target.x, target.z);
 }
 
 void camera_update_attract_random(camera_t *camera, ship_t *ship, droid_t *droid) {

--- a/src/wipeout/droid.c
+++ b/src/wipeout/droid.c
@@ -55,9 +55,9 @@ void droid_draw(droid_t *droid) {
 	droid->cycle_timer += system_tick() * M_PI * 2;
 
 	Prm prm = {.primitive = droid_model->primitives};
-	int rf = sin(droid->cycle_timer) * 127 + 128;
-	int gf = sin(droid->cycle_timer + 0.2) * 127 + 128;
-	int bf = sin(droid->cycle_timer * 0.5 + 0.1) * 127 + 128;
+	int rf = sinf(droid->cycle_timer) * 127 + 128;
+	int gf = sinf(droid->cycle_timer + 0.2) * 127 + 128;
+	int bf = sinf(droid->cycle_timer * 0.5 + 0.1) * 127 + 128;
 
 	for (int i = 0; i < 11; i++) {
 		rgba_t color;

--- a/src/wipeout/hud.c
+++ b/src/wipeout/hud.c
@@ -130,7 +130,7 @@ static void hud_draw_speedo_bars(vec2i_t *pos, float f, rgba_t color_override) {
 	}
 
 	if (f - floor(f) > 0.9) {
-		f = ceil(f);
+		f = ceilf(f);
 	}
 	if (f > 13) {
 		f = 13;

--- a/src/wipeout/scene.c
+++ b/src/wipeout/scene.c
@@ -207,7 +207,7 @@ void scene_set_start_booms(int light_index) {
 
 
 void scene_pulsate_red_light(Object *obj) {
-	uint8_t r = clamp(sin(system_cycle_time() * M_PI * 2) * 128 + 128, 0, 255);
+	uint8_t r = clamp(sinf(system_cycle_time() * M_PI * 2) * 128 + 128, 0, 255);
 	Prm libPoly = {.primitive = obj->primitives};
 
 	for (int v = 0; v < 4; v++) {
@@ -216,7 +216,7 @@ void scene_pulsate_red_light(Object *obj) {
 }
 
 void scene_move_oil_pump(Object *pump) {
-	mat4_set_yaw_pitch_roll(&pump->mat, vec3(sin(system_cycle_time() * 0.125 * M_PI * 2), 0, 0));
+	mat4_set_yaw_pitch_roll(&pump->mat, vec3(sinf(system_cycle_time() * 0.125 * M_PI * 2), 0, 0));
 }
 
 void scene_init_aurora_borealis(void) {
@@ -259,9 +259,9 @@ void scene_init_aurora_borealis(void) {
 
 rgba_t scene_aurora_color_from_coordinate(int16_t coord, float phase) {
 	return rgba(
-		 (sin(coord * phase) * 64.0) + 190,
-		 (sin(coord * (phase + 0.054)) * 64.0) + 190,
-		 (sin(coord * (phase + 0.039)) * 64.0) + 190,
+		 (sinf(coord * phase) * 64.0) + 190,
+		 (sinf(coord * (phase + 0.054)) * 64.0) + 190,
+		 (sinf(coord * (phase + 0.039)) * 64.0) + 190,
 		 0xFF
 	);
 }

--- a/src/wipeout/sfx.c
+++ b/src/wipeout/sfx.c
@@ -215,7 +215,7 @@ void sfx_set_position(sfx_t *sfx, vec3_t pos, vec3_t vel, float volume) {
 	float distance = vec3_len(relative_position);
 
 	sfx->volume = clamp(scale(distance, 512, 32768, 1, 0), 0, 1) * volume;
-	sfx->pan = -sin(atan2(g.camera.position.x - pos.x, g.camera.position.z - pos.z)+g.camera.angle.y);
+	sfx->pan = -sinf(atan2(g.camera.position.x - pos.x, g.camera.position.z - pos.z)+g.camera.angle.y);
 
 	// Doppler effect
 	float away = vec3_dot(relative_velocity, relative_position) / distance;

--- a/src/wipeout/ship_ai.c
+++ b/src/wipeout/ship_ai.c
@@ -30,7 +30,7 @@ void ship_ai_update_intro(ship_t *self) {
 }
 
 void ship_ai_update_intro_await_go(ship_t *self) {
-	self->position.y = self->temp_target.y + sin(self->update_timer * (80.0 + self->pilot * 3.0) * 30.0 * M_PI * 2.0 / 4096.0) * 32;
+	self->position.y = self->temp_target.y + sinf(self->update_timer * (80.0 + self->pilot * 3.0) * 30.0 * M_PI * 2.0 / 4096.0) * 32;
 
 	self->update_timer -= system_tick();
 	if (self->update_timer <= UPDATE_TIME_GO) {
@@ -472,7 +472,7 @@ void ship_ai_update_race(ship_t *self) {
 		self->velocity = vec3_add(self->velocity, vec3_mulf(self->acceleration, 30 * system_tick()));
 
 
-		float xy_dist = sqrt(track_target.x * track_target.x + track_target.z * track_target.z);
+		float xy_dist = sqrtf(track_target.x * track_target.x + track_target.z * track_target.z);
 
 		self->angular_velocity.x = wrap_angle(-atan2(track_target.y, xy_dist) - self->angle.x) * (1.0/16.0) * 30;
 		self->angular_velocity.y = (wrap_angle(-atan2(track_target.x, track_target.z) - self->angle.y) * (1.0/16.0)) * 30 + self->turn_rate_from_hit;

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -114,7 +114,7 @@ void ship_player_update_intro_await_go(ship_t *self) {
 
 void ship_player_update_intro_general(ship_t *self) {
 	self->update_timer -= system_tick();
-	self->position.y = self->temp_target.y + sin(self->update_timer * 80.0 * 30.0 * M_PI * 2.0 / 4096.0) * 32;
+	self->position.y = self->temp_target.y + sinf(self->update_timer * 80.0 * 30.0 * M_PI * 2.0 / 4096.0) * 32;
 
 	// Thrust
 	if (input_state(A_THRUST)) {

--- a/src/wipeout/track.c
+++ b/src/wipeout/track.c
@@ -320,9 +320,9 @@ void track_cycle_pickups(void) {
 		else if (g.track.pickups[i].cooldown_timer <= 0) {
 			flags_add(g.track.pickups[i].face->flags, FACE_PICKUP_ACTIVE);
 			track_face_set_color(g.track.pickups[i].face, rgba(
-				sin( pickup_cycle_time + i) * 127 + 128,
-				cos( pickup_cycle_time + i) * 127 + 128,
-				sin(-pickup_cycle_time - i) * 127 + 128,
+				sinf( pickup_cycle_time + i) * 127 + 128,
+				cosf( pickup_cycle_time + i) * 127 + 128,
+				sinf(-pickup_cycle_time - i) * 127 + 128,
 				255
 			));
 		}

--- a/src/wipeout/weapon.c
+++ b/src/wipeout/weapon.c
@@ -253,7 +253,7 @@ void weapon_follow_target(weapon_t *self) {
 	vec3_t angular_velocity = vec3(0, 0, 0);
 	if (self->target) {
 		vec3_t dir = vec3_mulf(vec3_sub(self->target->position, self->position), 0.125 * 30 * system_tick());
-		float height = sqrt(dir.x * dir.x + dir.z * dir.z);
+		float height = sqrtf(dir.x * dir.x + dir.z * dir.z);
 		angular_velocity.y = -atan2(dir.x, dir.z) - self->angle.y;
 		angular_velocity.x = -atan2(dir.y, height) - self->angle.x;
 	}
@@ -351,7 +351,7 @@ void weapon_update_mine_wait_for_release(weapon_t *self) {
 void weapon_update_mine_lights(weapon_t *self, int index) {
 	Prm prm = {.primitive = self->model->primitives};
 
-	uint8_t r = sin(system_cycle_time() * M_PI * 2 + index * 0.66) * 128 + 128;
+	uint8_t r = sinf(system_cycle_time() * M_PI * 2 + index * 0.66) * 128 + 128;
 	for (int i = 0; i < 8; i++) {
 		switch (prm.primitive->type) {
 		case PRM_TYPE_GT3:
@@ -577,9 +577,9 @@ void weapon_update_shield(weapon_t *self) {
 		case PRM_TYPE_G3 :
 			coords = poly.g3->coords;
 
-			col0 = sin(color_timer * coords[0]) * 127 + 128;
-			col1 = sin(color_timer * coords[1]) * 127 + 128;
-			col2 = sin(color_timer * coords[2]) * 127 + 128;
+			col0 = sinf(color_timer * coords[0]) * 127 + 128;
+			col1 = sinf(color_timer * coords[1]) * 127 + 128;
+			col2 = sinf(color_timer * coords[2]) * 127 + 128;
 
 			poly.g3->color[0] = rgba(col0, col0, 255, shield_alpha);
 			poly.g3->color[1] = rgba(col1, col1, 255, shield_alpha);
@@ -590,10 +590,10 @@ void weapon_update_shield(weapon_t *self) {
 		case PRM_TYPE_G4 :
 			coords = poly.g4->coords;
 
-			col0 = sin(color_timer * coords[0]) * 127 + 128;
-			col1 = sin(color_timer * coords[1]) * 127 + 128;
-			col2 = sin(color_timer * coords[2]) * 127 + 128;
-			col3 = sin(color_timer * coords[3]) * 127 + 128;
+			col0 = sinf(color_timer * coords[0]) * 127 + 128;
+			col1 = sinf(color_timer * coords[1]) * 127 + 128;
+			col2 = sinf(color_timer * coords[2]) * 127 + 128;
+			col3 = sinf(color_timer * coords[3]) * 127 + 128;
 
 			poly.g4->color[0] = rgba(col0, col0, 255, shield_alpha);
 			poly.g4->color[1] = rgba(col1, col1, 255, shield_alpha);


### PR DESCRIPTION
(#185) I changed all the `math.h` double precision math I could find to single precision. I can't just do a find-and-replace everywhere because there's GLSL and JS in the codebase as well. I found some other strange things in the process, but I'll submit those separately.

`vec3_len` would typically be called `vec3_mag`. If changing that is considered worthwhile I'll submit it alongside the `vec3_mag_sq` function.