### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/src/types.c
+++ b/src/types.c
@@ -16,10 +16,8 @@ vec3_t vec3_wrap_angle(vec3_t a) {
 }
 
 float vec3_angle(vec3_t a, vec3_t b) {
-	float magnitude = sqrtf(
-		(a.x * a.x + a.y * a.y + a.z * a.z) * 
-		(b.x * b.x + b.y * b.y + b.z * b.z)
-	);
+	float magnitude = vec3_len(a) * vec3_len(b);
+
 	float cosine = (magnitude == 0)
 		? 1
 		: vec3_dot(a, b) / magnitude;

--- a/src/types.h
+++ b/src/types.h
@@ -231,7 +231,7 @@ static inline vec3_t vec3_normalize(vec3_t a) {
 }
 
 static inline float wrap_angle(float a) {
-	a = fmod(a + M_PI, M_PI * 2);
+	a = fmodf(a + M_PI, M_PI * 2);
 	if (a < 0) {
 		a += M_PI * 2;
 	}

--- a/src/wipeout/camera.c
+++ b/src/wipeout/camera.c
@@ -114,7 +114,7 @@ void camera_update_attract_circle(camera_t *camera, ship_t *ship, droid_t *droid
 	camera->position = vec3_add(camera->position, vec3_mulf(ship->mat.basis.down.vec3, 256));
 	
 	vec3_t target = vec3_sub(ship->position, camera->position);
-	float height = sqrtf(target.x * target.x + target.z * target.z);
+	float height = vec3_len(vec3_mul(target, vec3(1,0,1)));
 	camera->angle.x = -atan2f(target.y, height);
 	camera->angle.y = -atan2f(target.x, target.z);
 }
@@ -123,7 +123,7 @@ void camera_update_rescue(camera_t *camera, ship_t *ship, droid_t *droid) {
 	camera->position = vec3_add(camera->section->center, vec3(300, -1500, 300));
 
 	vec3_t target = vec3_sub(droid->position, camera->position);
-	float height = sqrtf(target.x * target.x + target.z * target.z);
+	float height = vec3_len(vec3_mul(target, vec3(1,0,1)));
 	camera->angle.x = -atan2f(target.y, height);
 	camera->angle.y = -atan2f(target.x, target.z);
 }
@@ -147,7 +147,8 @@ void camera_update_static_follow(camera_t *camera, ship_t *ship, droid_t *droid)
 	}
 
 	vec3_t target = vec3_sub(ship->position, camera->position);
-	float height = sqrtf(target.x * target.x + target.z * target.z);
+	float height = vec3_len(vec3_mul(target, vec3(1,0,1)));
+
 	camera->angle.x = -atan2f(target.y, height);
 	camera->angle.y = -atan2f(target.x, target.z);
 }

--- a/src/wipeout/hud.c
+++ b/src/wipeout/hud.c
@@ -128,13 +128,10 @@ static void hud_draw_speedo_bars(vec2i_t *pos, float f, rgba_t color_override) {
 	if (f <= 0) {
 		return;
 	}
-
 	if (f - floor(f) > 0.9) {
 		f = ceilf(f);
 	}
-	if (f > 13) {
-		f = 13;
-	}
+	f = fminf(f,13);
 
 	int bars = f;
 	for (int i = 1; i < bars; i++) {
@@ -150,9 +147,8 @@ static void hud_draw_speedo_bars(vec2i_t *pos, float f, rgba_t color_override) {
 		return;
 	}
 
-	if (last_bar_fraction > 1) {
-		last_bar_fraction = 1;
-	}
+	last_bar_fraction = fminf(last_bar_fraction, 1);
+
 	int last_bar = bars == 0 ? 1 : bars;
 	hud_draw_speedo_bar(pos, &speedo.bars[last_bar - 1], &speedo.bars[last_bar], last_bar_fraction, color_override);
 }

--- a/src/wipeout/image.c
+++ b/src/wipeout/image.c
@@ -291,7 +291,6 @@ texture_list_t image_get_compressed_textures(char *name) {
 	texture_list_t list = {.start = render_textures_len(), .len = cmp->len};
 
 	for (int i = 0; i < cmp->len; i++) {
-		int32_t width, height;
 		image_t *image = image_load_from_bytes(cmp->entries[i], false);
 
 		// char png_name[1024] = {0};

--- a/src/wipeout/ingame_menus.c
+++ b/src/wipeout/ingame_menus.c
@@ -385,7 +385,6 @@ static void page_hall_of_fame_draw(menu_t *menu, int data) {
 		save.is_dirty = true;
 		
 		// Insert new highscore entry into the save struct
-		highscores_entry_t temp_entry = hs->entries[0];
 		for (int i = 0; i < NUM_HIGHSCORES; i++) {
 			if (hs_new_entry.time < hs->entries[i].time) {
 				for (int j = NUM_HIGHSCORES - 2; j >= i; j--) {

--- a/src/wipeout/menu.c
+++ b/src/wipeout/menu.c
@@ -9,7 +9,7 @@
 
 bool blink(void) {
 	// blink 30 times per second
-	return fmod(system_cycle_time(), 1.0/15.0) < 1.0/30.0;
+	return fmodf(system_cycle_time(), 1.0/15.0) < 1.0/30.0;
 }
 
 void menu_reset(menu_t *menu) {

--- a/src/wipeout/sfx.c
+++ b/src/wipeout/sfx.c
@@ -354,7 +354,7 @@ void sfx_stero_mix(float *buffer, uint32_t len) {
 			sfx->position += sfx->pitch;
 			if (sfx->position >= source->len) {
 				if (flags_is(sfx->flags, SFX_LOOP)) {
-					sfx->position = fmod(sfx->position, source->len);
+					sfx->position = fmodf(sfx->position, source->len);
 				}
 				else {
 					flags_rm(sfx->flags, SFX_PLAY);

--- a/src/wipeout/ship.c
+++ b/src/wipeout/ship.c
@@ -631,6 +631,8 @@ void ship_resolve_wing_collision(ship_t *self, track_face_t *face, float directi
 
 void ship_resolve_nose_collision(ship_t *self, track_face_t *face, float direction) {
 	vec3_t collision_vector = vec3_sub(self->section->center, face->tris[0].vertices[2].pos);
+	// TODO: In the PSX original, nose collisions change depending on the angle to the wall,
+	// but here this variable goes unused.
 	float angle = vec3_angle(collision_vector, self->mat.basis.forward.vec3);
 	self->velocity = vec3_reflect(self->velocity, face->normal, 2);
 	self->position = vec3_sub(self->position, vec3_mulf(self->velocity, 0.015625)); // system_tick?

--- a/src/wipeout/ship_ai.c
+++ b/src/wipeout/ship_ai.c
@@ -447,9 +447,7 @@ void ship_ai_update_race(ship_t *self) {
 		vec3_t face_point = face->tris[0].vertices[0].pos;
 		float height = vec3_distance_to_plane(self->position, face_point, face->normal);
 
-		if (height < 50) {
-			height = 50;
-		}
+		height = fmaxf(height, 50);
 
 		self->acceleration = vec3_add(self->acceleration, vec3_mulf(vec3_sub(
 			vec3_mulf(face->normal, (SHIP_TRACK_FLOAT * SHIP_TRACK_MAGNET) / height),
@@ -458,7 +456,7 @@ void ship_ai_update_race(ship_t *self) {
 		self->velocity = vec3_add(self->velocity, vec3_mulf(self->acceleration, 30 * system_tick()));
 
 
-		float xy_dist = sqrtf(track_target.x * track_target.x + track_target.z * track_target.z);
+		float xy_dist = vec3_len(vec3_mul(track_target, vec3(1,0,1)));
 
 		self->angular_velocity.x = wrap_angle(-atan2(track_target.y, xy_dist) - self->angle.x) * (1.0/16.0) * 30;
 		self->angular_velocity.y = (wrap_angle(-atan2(track_target.x, track_target.z) - self->angle.y) * (1.0/16.0)) * 30 + self->turn_rate_from_hit;

--- a/src/wipeout/ship_player.c
+++ b/src/wipeout/ship_player.c
@@ -362,9 +362,7 @@ void ship_player_update_race(ship_t *self) {
 			self->velocity = vec3_add(self->velocity, vec3_mulf(face->normal, 64.0 * 30 * system_tick()));
 		}
 
-		if (height < 50) {
-			height = 50;
-		}
+		height = fmaxf(height, 50);
 
 		// Calculate acceleration
 		float brake = (self->brake_left + self->brake_right);

--- a/src/wipeout/track.c
+++ b/src/wipeout/track.c
@@ -293,8 +293,6 @@ void track_draw(camera_t *camera) {
 	vec3_t cam_pos = camera->position;
 	vec3_t cam_dir = camera_forward(camera);
 	
-	int drawn = 0;
-	int skipped = 0;
 	for(int32_t i = 0; i < g.track.section_count; i++) {
 		section_t *s = &g.track.sections[i];
 		vec3_t diff = vec3_sub(cam_pos, s->center);

--- a/src/wipeout/weapon.c
+++ b/src/wipeout/weapon.c
@@ -11,10 +11,6 @@
 #include "particle.h"
 #include "camera.h"
 
-extern int32_t ctrlNeedTargetIcon;
-extern int ctrlnearShip;
-int16_t Shielded = 0;
-
 typedef struct weapon_t {
 	float timer;
 	ship_t *owner;
@@ -253,7 +249,7 @@ void weapon_follow_target(weapon_t *self) {
 	vec3_t angular_velocity = vec3(0, 0, 0);
 	if (self->target) {
 		vec3_t dir = vec3_mulf(vec3_sub(self->target->position, self->position), 0.125 * 30 * system_tick());
-		float height = sqrtf(dir.x * dir.x + dir.z * dir.z);
+		float height = vec3_len(vec3_mul(dir, vec3(1,0,1)));
 		angular_velocity.y = -atan2(dir.x, dir.z) - self->angle.y;
 		angular_velocity.x = -atan2(dir.y, height) - self->angle.x;
 	}


### PR DESCRIPTION
I'm trying to avoid grab-bag patches, but the alternative is tons of tiny ones.

- Using fminf/fmaxf instead of manual clamping
- vec3_len instead of manual lengths
- deleting unused variables
- changing some `double` functions that slipped through to `float`
- a comment

There's a strange idiom in the code which goes
`a = a - (a*0.25)`
instead of 
`a *= 0.75`.
I might try to find and fix them all later - I think it's just a remnant of older code that would shift and subtract, instead of doing a more expensive multiply (or maybe this was the only option in fixed-point?). The only other program I've seen do that was written in AVR assembly.