### PR TITLE
Quieter logging (and better music load logging)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ L_FLAGS ?= -lm
 C_FLAGS ?= -Isrc/libs/ -std=gnu99 -Wall -Wno-unused-variable $(USER_CFLAGS)
 
 ifeq ($(DEBUG), true)
-	C_FLAGS := $(C_FLAGS) -g
+	C_FLAGS := $(C_FLAGS) -g -DVERBOSE_PRINTING
 else
 	C_FLAGS := $(C_FLAGS) -O3
 endif

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -955,8 +955,9 @@ uint16_t render_texture_create(uint32_t tw, uint32_t th, rgba_t *pixels) {
 	uint16_t texture_index = textures_len;
 	textures_len++;
 	textures[texture_index] = (render_texture_t){ {x + ATLAS_BORDER, y + ATLAS_BORDER}, {tw, th} };
-
+#ifdef VERBOSE_PRINTING
 	printf("inserted atlas texture (%3dx%3d) at (%3d,%3d)\n", tw, th, grid_x, grid_y);
+#endif
 	return texture_index;
 }
 

--- a/src/wipeout/image.c
+++ b/src/wipeout/image.c
@@ -229,7 +229,9 @@ void lzss_decompress(uint8_t *in_data, uint8_t *out_data) {
 }
 
 cmp_t *image_load_compressed(char *name) {
-	printf("load cmp %s\n", name);
+#ifdef VERBOSE_PRINTING
+	printf("load: %s\n", name);
+#endif
 	uint32_t compressed_size;
 	uint8_t *compressed_bytes = platform_load_asset(name, &compressed_size);
 
@@ -263,7 +265,9 @@ cmp_t *image_load_compressed(char *name) {
 }
 
 uint16_t image_get_texture(char *name) {
+#ifdef VERBOSE_PRINTING
 	printf("load: %s\n", name);
+#endif
 	uint32_t size;
 	uint8_t *bytes = platform_load_asset(name, &size);
 	image_t *image = image_load_from_bytes(bytes, false);
@@ -275,7 +279,9 @@ uint16_t image_get_texture(char *name) {
 }
 
 uint16_t image_get_texture_semi_trans(char *name) {
+#ifdef VERBOSE_PRINTING
 	printf("load: %s\n", name);
+#endif
 	uint32_t size;
 	uint8_t *bytes = platform_load_asset(name, &size);
 	image_t *image = image_load_from_bytes(bytes, true);

--- a/src/wipeout/object.c
+++ b/src/wipeout/object.c
@@ -21,8 +21,9 @@ Object *objects_load(char *name, texture_list_t tl) {
 	if (!bytes) {
 		die("Failed to load file %s\n", name);
 	}
+#ifdef VERBOSE_PRINTING
 	printf("load: %s\n", name);
-
+#endif
 	Object *objectList = mem_mark();
 	Object *prevObject = NULL;
 	uint32_t p = 0;

--- a/src/wipeout/sfx.c
+++ b/src/wipeout/sfx.c
@@ -291,7 +291,7 @@ void sfx_music_play(uint32_t index) {
 		return;
 	}
 
-	printf("open music track %d\n", index);
+	printf("open music track %s\n", def.music[index].name);
 
 	music->track_index = index;
 	sfx_music_open(def.music[index].path);


### PR DESCRIPTION
wipeout-rewrite spews a *lot* of debugging information (mostly graphics related.) With this patch all these statements are still present, but are only compiled in for debug builds. I also changed the music track load logging to give the name of the track rather than the index.