### PR TITLE
Checking for game content fix

### DIFF
--- a/src/platform.h
+++ b/src/platform.h
@@ -10,6 +10,7 @@ bool platform_get_fullscreen(void);
 void platform_set_fullscreen(bool fullscreen);
 void platform_set_audio_mix_cb(void (*cb)(float *buffer, uint32_t len));
 
+bool platform_asset_exists(const char *name);
 FILE *platform_open_asset(const char *name, const char *mode);
 uint8_t *platform_load_asset(const char *name, uint32_t *bytes_read);
 uint8_t *platform_load_userdata(const char *name, uint32_t *bytes_read);

--- a/src/platform_null.c
+++ b/src/platform_null.c
@@ -24,6 +24,10 @@ void platform_set_audio_mix_cb(void (*cb)(float *buffer, uint32_t len)) {
 	(void) cb;
 }
 
+bool platform_asset_exists(const char *name) {
+	char *path = strcat(strcpy(temp_path, path_assets), name);
+	return file_exists(path);
+}
 FILE *platform_open_asset(const char *name, const char *mode) {
 	char *path = strcat(strcpy(temp_path, path_assets), name);
 	return fopen(path, mode);

--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -228,6 +228,11 @@ void platform_set_audio_mix_cb(void (*cb)(float *buffer, uint32_t len)) {
 }
 
 
+bool platform_asset_exists(const char *name) {
+	char *path = strcat(strcpy(temp_path, path_assets), name);
+	return file_exists(path);
+}
+
 FILE *platform_open_asset(const char *name, const char *mode) {
 	char *path = strcat(strcpy(temp_path, path_assets), name);
 	return fopen(path, mode);

--- a/src/platform_sokol.c
+++ b/src/platform_sokol.c
@@ -264,6 +264,11 @@ void platform_set_audio_mix_cb(void (*cb)(float *buffer, uint32_t len)) {
 	audio_callback = cb;
 }
 
+bool platform_asset_exists(const char *name) {
+	char *path = strcat(strcpy(temp_path, path_assets), name);
+	return file_exists(path);
+}
+
 FILE *platform_open_asset(const char *name, const char *mode) {
 	char *path = strcat(strcpy(temp_path, path_assets), name);
 	return fopen(path, mode);

--- a/src/wipeout/game.c
+++ b/src/wipeout/game.c
@@ -828,15 +828,15 @@ static int global_textures_len = 0;
 static void *global_mem_mark = 0;
 
 void game_init(void) {
-	error_if(!file_exists("wipeout/track01/"), "Wipeout game content missing. Check your wipeout/ directory.\n");
-	if (file_exists("wipeout2/track01/") || file_exists("wipeout64/track01/")) {
+	error_if(!platform_asset_exists("wipeout/track01/"), "Wipeout game content missing. Check your wipeout/ directory.\n");
+	if (platform_asset_exists("wipeout2/track01/") || platform_asset_exists("wipeout64/track01/")) {
 		g.additional_circuts = true;
 	}
 	printf("installed circuts:");
 	for (int i = 0; i < len(def.circuts); i++) {
 		g.installed_circuts[i] = true;
 		for (int o = 0; o < len(def.race_classes); o++) {
-			g.installed_circuts[i] &= file_exists(def.circuts[i].settings[o].path);
+			g.installed_circuts[i] &= platform_asset_exists(def.circuts[i].settings[o].path);
 		}
 		if (g.installed_circuts[i]) printf(" %s,", def.circuts[i].name);
 	}


### PR DESCRIPTION
`game_init` was abusing `file_exists` to check for the presence of game content. This works fine until you launch the game from outside its directory. Cleanly fixing my mistake required adding `platform_asset_exists` to the platform code.