### PR TITLE
Failure to compile on some platforms introduced by include cleanup fixed

### DIFF
--- a/src/wipeout/image.c
+++ b/src/wipeout/image.c
@@ -2,6 +2,7 @@
 #include "../mem.h"
 #include "../utils.h"
 #include "../platform.h"
+#include "../render.h"
 
 #include "image.h"
 


### PR DESCRIPTION
There was another transitive include removed by #192 that I did not catch. Bizarrely, this only fails to compile on my postmarketOS/google-veyron machine, which is why it wasn't caught along with `weapon.c`.

For completeness: 
`git pull` (from phoboslab master), `make clean`, `make -j` works fine (for unclear reasons) on Linux Mint/x86 but fails to compile on google-veyron. google-veyron requires GLX while the x86 machine does not, but I don't know why that would change anything here.