### PR TITLE
wrap_around function for more succinct menu code

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -66,3 +66,12 @@ float rand_float(float min, float max) {
 int32_t rand_int(int32_t min, int32_t max) {
 	return min + rand() % (max - min);
 }
+
+int wrap_around(int val, int min, int max) {
+	if (val >= max) {
+		return min;
+	} else if (val < min) {
+		return max - 1;
+	}
+	return val;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -77,6 +77,7 @@ char *get_path(const char *dir, const char *file);
 bool str_starts_with(const char *haystack, const char *needle);
 float rand_float(float min, float max);
 int32_t rand_int(int32_t min, int32_t max); 
+int wrap_around(int val, int min, int max);
 
 bool file_exists(const char *path);
 uint8_t *file_load(const char *path, uint32_t *bytes_read);

--- a/src/wipeout/ingame_menus.c
+++ b/src/wipeout/ingame_menus.c
@@ -331,13 +331,7 @@ static void hall_of_fame_draw_name_entry(menu_t *menu, ui_pos_t anchor, vec2i_t 
 	else if (input_pressed(A_MENU_DOWN)) {
 		hs_char_index--;
 	}
-
-	if (hs_char_index < c_first) {
-		hs_char_index = c_last-1;
-	}
-	if (hs_char_index >= c_last) {
-		hs_char_index = c_first;
-	}
+	hs_char_index = wrap_around(hs_char_index, c_first, c_last);
 
 	// DEL
 	if (hs_char_index == 36) {

--- a/src/wipeout/main_menu.c
+++ b/src/wipeout/main_menu.c
@@ -382,28 +382,17 @@ static void page_options_highscores_viewer_input_handler() {
 	else if (input_pressed(A_MENU_DOWN)) {
 		options_highscores_race_class++;
 	}
+	options_highscores_race_class = wrap_around(options_highscores_race_class, 0, NUM_RACE_CLASSES);
+
 	if (input_pressed(A_MENU_LEFT)) {
 		do {
-			options_highscores_circuit--;
-			if (options_highscores_circuit < 0) {
-				options_highscores_circuit = NUM_CIRCUITS - 1;
-			}
+			options_highscores_circuit = wrap_around(options_highscores_circuit - 1, 0, NUM_CIRCUITS);
 		} while (!g.installed_circuits[options_highscores_circuit]);
 	}
 	else if (input_pressed(A_MENU_RIGHT)) {
 		do {
-			options_highscores_circuit++;
-			if (options_highscores_circuit >= NUM_CIRCUITS) {
-				options_highscores_circuit = 0;
-			}
+			options_highscores_circuit = wrap_around(options_highscores_circuit + 1, 0, NUM_CIRCUITS);
 		} while (!g.installed_circuits[options_highscores_circuit]);
-	}
-
-	if (options_highscores_race_class >= NUM_RACE_CLASSES) {
-		options_highscores_race_class = 0;
-	}
-	if (options_highscores_race_class < 0) {
-		options_highscores_race_class = NUM_RACE_CLASSES - 1;
 	}
 
 	if ((last_race_class_index != options_highscores_race_class) ||

--- a/src/wipeout/menu.c
+++ b/src/wipeout/menu.c
@@ -101,13 +101,7 @@ void menu_update(menu_t *menu) {
 				page->index++;
 			}
 		}
-
-		if (page->index >= page->entries_len) {
-			page->index = 0;
-		}
-		if (page->index < 0) {
-			page->index = page->entries_len - 1;
-		}
+		page->index = wrap_around(page->index, 0, page->entries_len);
 
 		if (last_index != page->index) {
 			sfx_play(SFX_MENU_MOVE);
@@ -213,17 +207,16 @@ void menu_update(menu_t *menu) {
 	if (entry->type == MENU_ENTRY_TOGGLE) {
 		if (input_pressed(A_MENU_LEFT)) {
 			sfx_play(SFX_MENU_SELECT);
-			entry->data--;
-			if (entry->data < 0) {
-				entry->data = entry->options_len-1;
-			}
+			entry->data = wrap_around(entry->data - 1, 0, entry->options_len);
+
 			if (entry->select_func) {
 				entry->select_func(menu, entry->data);
 			}
 		}
 		else if (input_pressed(A_MENU_RIGHT) || input_pressed(A_MENU_SELECT) || input_pressed(A_MENU_START)) {
 			sfx_play(SFX_MENU_SELECT);
-			entry->data = (entry->data + 1) % entry->options_len;
+			entry->data = wrap_around(entry->data + 1, 0, entry->options_len);
+
 			if (entry->select_func) {
 				entry->select_func(menu, entry->data);
 			}
@@ -236,7 +229,7 @@ void menu_update(menu_t *menu) {
 			if (entry->select_func) {
 				sfx_play(SFX_MENU_SELECT);
 				if (entry->type == MENU_ENTRY_TOGGLE) {
-					entry->data = (entry->data + 1) % entry->options_len;
+					entry->data = wrap_around(entry->data + 1, 0, entry->options_len);
 				}
 				entry->select_func(menu, entry->data);
 			}


### PR DESCRIPTION
The menu code frequently needs to loop a value around to the beginning/end of a sequence. Instead of several different expressions of this concept, there is now only one which lives in `utils.c`. I considered making it into a macro, since it's so trivial - but I don't know whether that'd be well suited to this?