### PR TITLE
Remove pointless line in vec3_distance_to_plane

### DIFF
--- a/src/types.c
+++ b/src/types.c
@@ -53,9 +53,7 @@ vec3_t vec3_project_to_ray(vec3_t p, vec3_t r0, vec3_t r1) {
 }
 
 float vec3_distance_to_plane(vec3_t p, vec3_t plane_pos, vec3_t plane_normal) {
-	float dot_product = vec3_dot(vec3_sub(plane_pos, p), plane_normal);
-	float norm_dot_product = vec3_dot(vec3_mulf(plane_normal, -1), plane_normal);
-	return dot_product / norm_dot_product;
+	return -vec3_dot(vec3_sub(plane_pos, p), plane_normal);
 }
 
 vec3_t vec3_reflect(vec3_t incidence, vec3_t normal, float f) {


### PR DESCRIPTION
The dot product of a vector and its negation is always -1. This function is fairly hot, and the compiler fails to optimize this out, even on `-Ofast`. The extra operations also reduce accuracy. It's unclear to me what the original purpose of this line was.

This function would be even simpler and faster if planes were stored properly, as `vec4_t`'s, but this is the hand we were dealt.