### PR TITLE
#192 fallout: render_software compiles again

### DIFF
--- a/src/render_software.c
+++ b/src/render_software.c
@@ -1,3 +1,4 @@
+#include "platform.h"
 #include "render.h"
 #include "mem.h"
 #include "utils.h"


### PR DESCRIPTION
#192 silently broke `render_software`, it now works again.