### PR TITLE
Use desktop fullscreen on macOS

### DIFF
--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -16,6 +16,13 @@ static char *path_assets = "";
 static char *path_userdata = "";
 static char *temp_path = NULL;
 
+#ifdef __APPLE__
+	// macOS behaves best with desktop fullscreen (Space-based, non-exclusive).
+	#define USE_FULLSCREEN_DESKTOP 1
+#else
+	#define USE_FULLSCREEN_DESKTOP 0
+#endif
+
 
 uint8_t platform_sdl_gamepad_map[] = {
 	[SDL_CONTROLLER_BUTTON_A] = INPUT_GAMEPAD_A,
@@ -199,12 +206,14 @@ bool platform_get_fullscreen(void) {
 
 void platform_set_fullscreen(bool fullscreen) {
 	if (fullscreen) {
-		int32_t display = SDL_GetWindowDisplayIndex(window);
-		
-		SDL_DisplayMode mode;
-		SDL_GetDesktopDisplayMode(display, &mode);
-		SDL_SetWindowDisplayMode(window, &mode);
-		SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN);
+		#if !USE_FULLSCREEN_DESKTOP
+			int32_t display = SDL_GetWindowDisplayIndex(window);
+
+			SDL_DisplayMode mode;
+			SDL_GetDesktopDisplayMode(display, &mode);
+			SDL_SetWindowDisplayMode(window, &mode);
+		#endif
+		SDL_SetWindowFullscreen(window, USE_FULLSCREEN_DESKTOP ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_FULLSCREEN);
 		SDL_ShowCursor(SDL_DISABLE);
 	}
 	else {


### PR DESCRIPTION
This appears to match how most modern macOS games handle fullscreen: using a borderless, space-based fullscreen window that behaves properly with Mission Control and Cmd+Tab.